### PR TITLE
Use long context length for gpqa bench

### DIFF
--- a/slurm_runner/job_script_template_disagg.j2
+++ b/slurm_runner/job_script_template_disagg.j2
@@ -34,6 +34,10 @@ CONFIG_DIR="{{ config_dir }}"
 CONTAINER_IMAGE="{{ container_image }}"
 NETWORK_INTERFACE="{{ network_interface }}"
 GPU_TYPE="{{ gpu_type | default('h100') }}"
+
+BENCHMARK_TYPE={{ benchmark_type }}
+BENCHMARK_ARGS="{{ benchmark_arg }}"
+
 set +x
 
 {% raw %}
@@ -180,7 +184,7 @@ ENROOT_ARGS="\
 {% endraw %}
 SCRIPT_VARIANT="{{ script_variant }}"
 {% raw %}
-WORKER_ARGS="--gpu_type ${GPU_TYPE} --script-variant ${SCRIPT_VARIANT} --gpus_per_node ${GPUS_PER_NODE} --master_ip ${MASTER_IP}"
+WORKER_ARGS="--gpu_type ${GPU_TYPE} --script-variant ${SCRIPT_VARIANT} --gpus_per_node ${GPUS_PER_NODE} --master_ip ${MASTER_IP} --bench-type ${BENCHMARK_TYPE}"
 {% endraw %}
 {% if enable_multiple_frontends %}
 {% raw %}
@@ -336,9 +340,6 @@ echo "scancel $SLURM_JOB_ID"
 # Instead of waiting for all tasks to complete, wait for benchmark to complete and then exit.
 
 {% endraw %}
-
-BENCHMARK_TYPE={{ benchmark_type }}
-BENCHMARK_ARGS="{{ benchmark_arg }}"
 
 {% if do_benchmark %}
 {% raw %}

--- a/slurm_runner/scripts/gb200-fp4/disagg/max-tpt.sh
+++ b/slurm_runner/scripts/gb200-fp4/disagg/max-tpt.sh
@@ -72,6 +72,14 @@ if [ -z "$USE_INIT_LOCATIONS" ]; then
     exit 1
 fi
 
+
+# Check whether the override env vars are set. If not, we just use the alternate values.
+CONTEXT_LENGTH=2176
+if [ -n "SERVER_CONTEXT_LENGTH" ]; then
+    echo "Warning: SERVER_CONTEXT_LENGTH ($SERVER_CONTEXT_LENGTH) is set, overrideing default $CONTEXT_LENGTH"
+    CONTEXT_LENGTH=$SERVER_CONTEXT_LENGTH
+fi
+
 # Construct command based on mode
 if [ "$mode" = "prefill" ]; then
     set -x
@@ -117,7 +125,7 @@ if [ "$mode" = "prefill" ]; then
         $DISAGG_MODE_FLAG \
         --decode-log-interval 1000 \
         --max-running-requests 30000 \
-        --context-length 2176 \
+        --context-length $CONTEXT_LENGTH \
         --disable-radix-cache \
         --disable-shared-experts-fusion \
         --watchdog-timeout 1000000 \
@@ -202,7 +210,7 @@ elif [ "$mode" = "decode" ]; then
         --host 0.0.0.0 \
         --decode-log-interval 1000 \
         --max-running-requests 67584 \
-        --context-length 2176 \
+        --context-length $CONTEXT_LENGTH \
         --disable-radix-cache \
         --disable-shared-experts-fusion \
         --watchdog-timeout 1000000 \


### PR DESCRIPTION
Allow the worker script to accept the benchmark type so that it can adjust the env vars accordingly. The env vars then will be absorbed by the server launchers to meet the benchmark purpose.

For example, the gpqa accuracy test, the`--context-length` argument for sglang launching needs to be changed to a larger value (e.g. 40000) which covers the `max-tokens`. This PR can help users to do that automatically.

