### PR TITLE
Add sglang_router support for expert distribution recording

### DIFF
--- a/examples/sglang-router-example.yaml
+++ b/examples/sglang-router-example.yaml
@@ -1,0 +1,119 @@
+# SGLang Router Mode Example Configuration
+# This configuration uses sglang_router.launch_router instead of the dynamo stack
+# Useful for expert distribution recording and custom routing
+
+name: "sglang-router-example"
+
+model:
+  path: "/models/deepseek-r1"
+  container: "/containers/sglang.sqsh"
+  precision: "fp8"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  # Enable sglang_router mode - uses sglang.launch_server for workers
+  # and sglang_router.launch_router instead of dynamo.frontend
+  use_sglang_router: true
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served_model_name: "deepseek-ai/DeepSeek-R1"
+      model_path: "/model/"
+      trust_remote_code: true
+
+      # KV cache and attention
+      kv_cache_dtype: "fp8_e4m3"
+      attention_backend: "trtllm_mla"
+
+      # Quantization
+      quantization: "fp8"
+      moe_runner_backend: "flashinfer_trtllm"
+
+      # Disaggregation
+      disaggregation_mode: "prefill"
+      disaggregation_bootstrap_port: 30001
+
+      # Parallelism
+      tp_size: 4
+      dp_size: 1
+      ep_size: 4
+
+      # Memory and tokens
+      mem_fraction_static: 0.85
+      max_total_tokens: 8192
+      chunked_prefill_size: 8192
+      max_running_requests: 512
+
+      # Other settings
+      disable_radix_cache: true
+      stream_interval: 10
+      watchdog_timeout: 1000000
+      context_length: 2200
+
+    decode:
+      # Model configuration
+      served_model_name: "deepseek-ai/DeepSeek-R1"
+      model_path: "/model/"
+      trust_remote_code: true
+
+      # KV cache and attention
+      kv_cache_dtype: "fp8_e4m3"
+      attention_backend: "trtllm_mla"
+
+      # Quantization
+      quantization: "fp8"
+      moe_runner_backend: "flashinfer_trtllm"
+
+      # Disaggregation
+      disaggregation_mode: "decode"
+      disaggregation_bootstrap_port: 30001
+
+      # Parallelism
+      tp_size: 4
+      dp_size: 1
+      ep_size: 4
+
+      # Memory and tokens
+      mem_fraction_static: 0.85
+      chunked_prefill_size: 8192
+      max_running_requests: 512
+
+      # Other settings
+      disable_radix_cache: true
+      stream_interval: 10
+      watchdog_timeout: 1000000
+      context_length: 2200
+      prefill_round_robin_balance: true
+
+benchmark:
+  type: "manual"  # No automatic benchmarking
+
+# Notes:
+# - sglang_router mode uses sglang.launch_server for workers (not dynamo.sglang)
+# - Router is launched on the first prefill node on port 8000
+# - Router connects to all prefill and decode worker leaders
+# - Workers expose ports 30000 (prefill) and 30001 (decode)
+# - Bootstrap port 30001 is used for prefill workers only
+# - This mode is useful for expert distribution recording and custom routing logic

--- a/scripts/templates/job_script_template_disagg.j2
+++ b/scripts/templates/job_script_template_disagg.j2
@@ -196,6 +196,12 @@ WORKER_ARGS="$WORKER_ARGS --multiple-frontends-enabled"
 WORKER_ARGS="$WORKER_ARGS --sglang-torch-profiler"
 {% endraw %}
 {% endif %}
+{% if use_sglang_router %}
+{% raw %}
+# Enable sglang_router mode
+WORKER_ARGS="$WORKER_ARGS --use-sglang-router"
+{% endraw %}
+{% endif %}
 {% raw %}
 # Add SGLang config path (mounted in container at /logs/)
 WORKER_ARGS="$WORKER_ARGS --sglang-config-path /logs/sglang_config.yaml"
@@ -207,7 +213,53 @@ WORKER_ARGS="$WORKER_ARGS --setup-script {{ setup_script }}"
 {% raw %}
 
 {% endraw %}
-{% if enable_multiple_frontends %}
+{% if use_sglang_router %}
+{% raw %}
+# ============================
+# SGLang Router Mode
+# ============================
+# Collect all prefill leader IPs
+PREFILL_LEADER_IPS=()
+PREFILL_BOOTSTRAP_PORTS=()
+for worker_idx in $(seq 0 $((PREFILL_WORKERS - 1))); do
+    leader_idx=${prefill_leaders[$worker_idx]}
+    leader_node=${nodes[$leader_idx]}
+    leader_ip=$(get_node_ip "$leader_node" "$SLURM_JOB_ID" "$NETWORK_INTERFACE")
+    PREFILL_LEADER_IPS+=("$leader_ip")
+    PREFILL_BOOTSTRAP_PORTS+=(30001)
+    echo "Prefill worker $worker_idx leader: $leader_node ($leader_ip)"
+done
+
+# Collect all decode leader IPs
+DECODE_LEADER_IPS=()
+for worker_idx in $(seq 0 $((DECODE_WORKERS - 1))); do
+    leader_idx=${decode_leaders[$worker_idx]}
+    leader_node=${nodes[$leader_idx]}
+    leader_ip=$(get_node_ip "$leader_node" "$SLURM_JOB_ID" "$NETWORK_INTERFACE")
+    DECODE_LEADER_IPS+=("$leader_ip")
+    echo "Decode worker $worker_idx leader: $leader_node ($leader_ip)"
+done
+
+# Build router command with all prefill and decode endpoints
+ROUTER_NODE=${nodes[0]}
+echo "Launching sglang_router on ${ROUTER_NODE}"
+
+# Build prefill and decode arguments
+PREFILL_ARGS=""
+for i in "${!PREFILL_LEADER_IPS[@]}"; do
+    PREFILL_ARGS="$PREFILL_ARGS --prefill_ip ${PREFILL_LEADER_IPS[$i]}"
+done
+
+DECODE_ARGS=""
+for i in "${!DECODE_LEADER_IPS[@]}"; do
+    DECODE_ARGS="$DECODE_ARGS --decode_ip ${DECODE_LEADER_IPS[$i]}"
+done
+
+cmd="srun --overlap $ENROOT_ARGS --nodes=1 --ntasks=1 --nodelist=$ROUTER_NODE --output=${LOG_DIR}/${ROUTER_NODE}_router.out --error=${LOG_DIR}/${ROUTER_NODE}_router.err python /scripts/worker_setup.py --worker_type router --master_ip ${PREFILL_LEADER_IPS[0]} --prefill_bootstrap_port 30001 ${PREFILL_ARGS} ${DECODE_ARGS}"
+echo "$cmd"
+$cmd &
+{% endraw %}
+{% elif enable_multiple_frontends %}
 {% raw %}
 {% endraw %}
 {% if total_nodes > 1 %}

--- a/scripts/worker_setup/__init__.py
+++ b/scripts/worker_setup/__init__.py
@@ -5,7 +5,7 @@
 
 from .command import build_sglang_command_from_yaml, get_gpu_command, install_dynamo_wheels
 from .environment import setup_env
-from .infrastructure import setup_frontend_worker, setup_head_prefill_node, setup_nginx_worker
+from .infrastructure import setup_frontend_worker, setup_head_prefill_node, setup_nginx_worker, setup_sglang_router
 from .utils import setup_logging, wait_for_etcd
 from .worker import setup_aggregated_worker, setup_decode_worker, setup_prefill_worker
 
@@ -20,6 +20,7 @@ __all__ = [
     "setup_frontend_worker",
     "setup_head_prefill_node",
     "setup_nginx_worker",
+    "setup_sglang_router",
     # Utils
     "setup_logging",
     "wait_for_etcd",

--- a/scripts/worker_setup/worker.py
+++ b/scripts/worker_setup/worker.py
@@ -61,6 +61,7 @@ def setup_prefill_worker(
     gpu_type: str,
     multiple_frontends_enabled: bool = False,
     sglang_torch_profiler: bool = False,
+    use_sglang_router: bool = False,
     sglang_config_path: str | None = None,
     dump_config_path: str | None = None,
     setup_script: str | None = None,
@@ -112,6 +113,7 @@ def setup_prefill_worker(
         total_nodes=nodes_per_worker,
         rank=local_rank,
         use_profiling=sglang_torch_profiler,
+        use_sglang_router=use_sglang_router,
         dump_config_path=dump_config_path,
     )
     return run_command(cmd_to_run)
@@ -125,6 +127,7 @@ def setup_decode_worker(
     nodes_per_worker: int,
     gpu_type: str,
     sglang_torch_profiler: bool = False,
+    use_sglang_router: bool = False,
     sglang_config_path: str | None = None,
     dump_config_path: str | None = None,
     setup_script: str | None = None,
@@ -154,6 +157,7 @@ def setup_decode_worker(
         total_nodes=nodes_per_worker,
         rank=local_rank,
         use_profiling=sglang_torch_profiler,
+        use_sglang_router=use_sglang_router,
         dump_config_path=dump_config_path,
     )
     return run_command(cmd_to_run)
@@ -168,6 +172,7 @@ def setup_aggregated_worker(
     gpu_type: str,
     multiple_frontends_enabled: bool = False,
     sglang_torch_profiler: bool = False,
+    use_sglang_router: bool = False,
     sglang_config_path: str | None = None,
     dump_config_path: str | None = None,
     setup_script: str | None = None,
@@ -219,6 +224,7 @@ def setup_aggregated_worker(
         total_nodes=nodes_per_worker,
         rank=local_rank,
         use_profiling=sglang_torch_profiler,
+        use_sglang_router=use_sglang_router,
         dump_config_path=dump_config_path,
     )
     return run_command(cmd_to_run)

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -308,6 +308,7 @@ class SGLangBackend(Backend):
             "enable_config_dump": self._get_enable_config_dump(),
             "log_dir_prefix": str(log_dir_path),  # Absolute path to logs directory
             "sglang_torch_profiler": self.backend_config.get("enable_profiling", False),
+            "use_sglang_router": self.backend_config.get("use_sglang_router", False),
             "setup_script": self.setup_script,
             "use_gpus_per_node_directive": get_srtslurm_setting("use_gpus_per_node_directive", True),
             "extra_container_mounts": ",".join(self.config.get("extra_mount") or []),

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -223,6 +223,12 @@ class BackendConfig(BaseModel):
         description="Enable torch profiling mode (uses sglang.launch_server instead of dynamo.sglang)",
     )
 
+    # Router mode settings
+    use_sglang_router: bool = Field(
+        False,
+        description="Use sglang_router.launch_router instead of dynamo stack (enables sglang.launch_server)",
+    )
+
 
 class JobConfig(BaseModel):
     """Complete job configuration."""


### PR DESCRIPTION
## Summary

This PR adds support for using `sglang_router.launch_router` instead of the dynamo stack (NATS/ETCD/dynamo.frontend). This is the foundation for enabling expert distribution recording functionality.

## Key Changes

### 1. Configuration Layer
- Added `use_sglang_router` field to `BackendConfig` schema
- Users can now set `use_sglang_router: true` in their YAML configs

### 2. Worker Command Building
- Updated `command.py` to use `sglang.launch_server` when either `use_profiling` or `use_sglang_router` is enabled
- Workers properly configured with `--port 30001` and disaggregation settings

### 3. Router Infrastructure
- New `setup_sglang_router()` function in `infrastructure.py`
- Supports multiple prefill and decode worker groups
- Constructs router command with multiple `--prefill` and `--decode` endpoints
- Router runs on port 8000 (compatible with existing nginx setup)

### 4. SLURM Template Updates
- Modified disaggregated job template to conditionally launch router
- Automatically collects all prefill/decode worker leader IPs
- Skips NATS/ETCD/dynamo.frontend when using sglang_router

### 5. CLI Integration
- Added `router` worker type to worker_setup.py
- Added `--use-sglang-router` flag support throughout the stack
- Proper validation for router-specific arguments

### 6. Example Configuration
- Created `examples/sglang-router-example.yaml` with complete working example

## Architecture

When `use_sglang_router: true`:
- Router launched on first prefill node (port 8000)
- Router connects to all prefill workers (port 30000, bootstrap: 30001)
- Router connects to all decode workers (port 30001)
- Workers use `sglang.launch_server` instead of `dynamo.sglang`
- No NATS/ETCD/dynamo.frontend overhead

## Usage

```yaml
backend:
  use_sglang_router: true
  sglang_config:
    prefill:
      disaggregation_mode: "prefill"
      disaggregation_bootstrap_port: 30001
      # ... other config
    decode:
      disaggregation_mode: "decode"
      disaggregation_bootstrap_port: 30001
      # ... other config
```

## Testing

- Schema validation works correctly
- Template generation includes proper router setup
- CLI arguments properly propagated through the stack

## Next Steps

This PR lays the foundation for Phase 2: expert distribution recording, which will add:
- `enable_expert_recording` configuration option
- HTTP API triggers for recording (start/dump)
- Expert distribution analysis tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>