### PR TITLE
only run up to conc32 for low lat

### DIFF
--- a/recipies/gb200-fp8/8k1k/low-latency.yaml
+++ b/recipies/gb200-fp8/8k1k/low-latency.yaml
@@ -107,5 +107,5 @@ benchmark:
   type: "sa-bench"
   isl: 8192 
   osl: 1024
-  concurrencies: "4x8x16x32x64x128x256x512"
+  concurrencies: "4x8x16x32"
   req_rate: "inf"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted benchmark configuration parameters for low-latency performance testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->