### PR TITLE
Update mtp recipes to 0.5.7

### DIFF
--- a/configs/gb200-fp4-mtp-setup.sh
+++ b/configs/gb200-fp4-mtp-setup.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-BRANCH="baizhou/gb200-spec"
+BRANCH="gb200-spec"
 
 cd /sgl-workspace/sglang
 git remote remove origin
 git remote add origin https://github.com/sgl-project/sglang.git
 git fetch origin
 git checkout origin/${BRANCH}
+pip install mooncake-transfer-engine==0.3.7.post2

--- a/recipies/gb200-fp4/1k1k/max-tpt-mtp.yaml
+++ b/recipies/gb200-fp4/1k1k/max-tpt-mtp.yaml
@@ -4,7 +4,7 @@ name: "gb200-fp4-max-tpt-mtp"
 
 model:
   path: "dsfp4"
-  container: "0.5.6.post2"
+  container: "0.5.7"
   precision: "fp4"
 
 resources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GB200-FP4 setup configuration script with revised branch targeting and added mooncake-transfer-engine package (version 0.3.7.post2) installation
  * Upgraded GB200-FP4 model container image version from 0.5.6.post2 to 0.5.7

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->