### PR TITLE
Add GB200 DSR1-FP4 1k/8k recipies

### DIFF
--- a/recipies/gb200-fp4/1k8k/low-latency.yaml
+++ b/recipies/gb200-fp4/1k8k/low-latency.yaml
@@ -2,7 +2,7 @@ name: "gb200-fp4-1p2d"
 
 model:
   path: "dsfp4"
-  container: "0.5.5.post2"
+  container: "lmsysorg/sglang:dev-cu13"
   precision: "fp4"
 
 resources:

--- a/recipies/gb200-fp4/1k8k/max-tpt.yaml
+++ b/recipies/gb200-fp4/1k8k/max-tpt.yaml
@@ -4,7 +4,7 @@ name: "gb200-fp4-max-tpt"
 
 model:
   path: "dsfp4"
-  container: "0.5.5.post2"
+  container: "lmsysorg/sglang:dev-cu13"
   precision: "fp4"
 
 resources:

--- a/recipies/gb200-fp4/1k8k/mid-curve.yaml
+++ b/recipies/gb200-fp4/1k8k/mid-curve.yaml
@@ -5,7 +5,7 @@ name: "gb200-fp4-max-tpt-2"
 
 model:
   path: "dsfp4"
-  container: "0.5.5.post2"
+  container: "lmsysorg/sglang:dev-cu13"
   precision: "fp4"
 
 resources:


### PR DESCRIPTION
This is a preliminary 1k/8k recipes for GB200 DSR1-FP4. The recipe were modified from 1k/1k to get preliminary results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three GB200 FP4 configuration profiles (low-latency, max-throughput, balanced) for multi-stage inference. Each profile provides prefill/decode staging, resource and GPU/node allocation, environment and model-serving tuning, memory/token limits, parallelism/optimization options, and benchmark settings for performance validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->