### PR TITLE
added DYN_REQUEST_PLANE=nats for worker

### DIFF
--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -115,6 +115,7 @@ class WorkerStageMixin:
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.head}:2379",
             "NATS_SERVER": f"nats://{self.runtime.nodes.head}:4222",
             "DYN_SYSTEM_PORT": str(process.sys_port),
+            "DYN_REQUEST_PLANE": "nats",
         }
 
         # Add mode-specific environment variables from backend


### PR DESCRIPTION
dynamo 0.8.0 will default to TCP otherwise, but current frontend uses nats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker configuration to include request plane settings, enhancing worker process capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->