### PR TITLE
Remove GB200 DSR1-FP4 1k/8k concurrencies that will not show up on pareto curve

### DIFF
--- a/recipies/gb200-fp4/1k8k/low-latency.yaml
+++ b/recipies/gb200-fp4/1k8k/low-latency.yaml
@@ -108,5 +108,5 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 8192
-  concurrencies: "4x8x32x64x112"
+  concurrencies: "4x8x16x32"
   req_rate: "inf"

--- a/recipies/gb200-fp4/1k8k/max-tpt.yaml
+++ b/recipies/gb200-fp4/1k8k/max-tpt.yaml
@@ -240,5 +240,5 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 8192
-  concurrencies: "1x128x512x2048x4096x8192"
+  concurrencies: "256x512x1024x2048x8192"
   req_rate: "inf"

--- a/recipies/gb200-fp4/1k8k/mid-curve.yaml
+++ b/recipies/gb200-fp4/1k8k/mid-curve.yaml
@@ -240,5 +240,5 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 8192
-  concurrencies: "1x128x512x2048x4096x8192"
+  concurrencies: "2048x4096x8192"
   req_rate: "inf"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted benchmark configuration parameters across performance testing profiles to optimize workload specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->