### PR TITLE
Add low-latency FP8 disagg with MTP for GB200

### DIFF
--- a/recipes/gb200-fp8/1k1k/low-latency-mtp.yaml
+++ b/recipes/gb200-fp8/1k1k/low-latency-mtp.yaml
@@ -1,4 +1,4 @@
-name: "gb200-fp8-1p-4d-low-latency-mtp"
+name: "gb200-fp8-1p-2d-low-latency-mtp"
 
 model:
   path: "dsfp8"
@@ -104,7 +104,6 @@ backend:
       cuda-graph-max-bs: 256
       max-running-requests: 512
       scheduler-recv-interval: 10
-      #enable-flashinfer-allreduce-fusion: true
       enable-symm-mem: true
       moe-dense-tp-size: 1
       prefill-round-robin-balance: true


### PR DESCRIPTION
Based on `recipes/gb200-fp8/1k1k/low-latency.yaml` but with MTP enabled. I had to move the decode workers from 4xTP4 -> 2xTP8 due to memory limitations

```
diff recipes/gb200-fp8/1k1k/low-latency.yaml recipes/gb200-fp8/1k1k/low-latency-mtp.yaml 
1c1
< name: "gb200-fp8-1p-4d-low-latency"
---
> name: "gb200-fp8-1p-2d-low-latency-mtp"
5c5
<   container: "0.5.5.post2"
---
>   container: "0.5.8"
13c13
<   decode_workers: 4
---
>   decode_workers: 2
33a34
>     SGLANG_ENABLE_SPEC_V2: "1"
53a55
>     SGLANG_ENABLE_SPEC_V2: "1"
57a60
>       model-path: "/model/"
68c71
<       mem-fraction-static: 0.95
---
>       mem-fraction-static: 0.90
80a84,87
>       speculative-algorithm: "EAGLE"
>       speculative-num-steps: 2
>       speculative-eagle-topk: 1
>       speculative-num-draft-tokens: 3
83a91
>       model-path: "/model/"
94c102
<       mem-fraction-static: 0.95
---
>       mem-fraction-static: 0.90
96c104
<       cuda-graph-max-bs: 128
---
>       cuda-graph-max-bs: 256
99d106
<       enable-flashinfer-allreduce-fusion: true
103c110
<       tensor-parallel-size: 4
---
>       tensor-parallel-size: 8
105a113,116
>       speculative-algorithm: "EAGLE"
>       speculative-num-steps: 2
>       speculative-eagle-topk: 1
>       speculative-num-draft-tokens: 3
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new low-latency multi-token prediction configuration for GB200 FP8. Includes staged prefill/decode setup, tuned resource allocation across stages, extensive environment-level performance and compatibility tuning, and benchmark parameters to improve throughput and latency for FP8 models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->