### PR TITLE
Add MTP (Multi-Token Prediction) recipe variants for H200 configurations

### DIFF
--- a/recipes/h200/1k1k/bs128-agg-tp-mtp.yaml
+++ b/recipes/h200/1k1k/bs128-agg-tp-mtp.yaml
@@ -28,6 +28,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/1k1k/bs256-1p6d-dep-mtp.yaml
+++ b/recipes/h200/1k1k/bs256-1p6d-dep-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -75,6 +76,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/1k1k/bs256-1p6d-tp-mtp.yaml
+++ b/recipes/h200/1k1k/bs256-1p6d-tp-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -75,6 +76,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/1k1k/low-latency-1p9d-mtp.yaml
+++ b/recipes/h200/1k1k/low-latency-1p9d-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -74,6 +75,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs128-1p1d-dep-mtp.yaml
+++ b/recipes/h200/8k1k/bs128-1p1d-dep-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -75,6 +76,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs128-agg-tp-mtp.yaml
+++ b/recipes/h200/8k1k/bs128-agg-tp-mtp.yaml
@@ -28,6 +28,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs16-1p3d-mtp.yaml
+++ b/recipes/h200/8k1k/bs16-1p3d-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -74,6 +75,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs4-1p7d-mtp.yaml
+++ b/recipes/h200/8k1k/bs4-1p7d-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -74,6 +75,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs64-2p3d-mtp.yaml
+++ b/recipes/h200/8k1k/bs64-2p3d-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -74,6 +75,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8

--- a/recipes/h200/8k1k/bs8-1p6d-mtp.yaml
+++ b/recipes/h200/8k1k/bs8-1p6d-mtp.yaml
@@ -38,6 +38,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8
@@ -75,6 +76,7 @@ backend:
       model-path: "/model/"
       skip-tokenizer-init: true
       trust-remote-code: true
+      watchdog-timeout: 1000000
 
       # Parallelism
       tp-size: 8


### PR DESCRIPTION
## Summary

This PR adds MTP (Multi-Token Prediction / Speculative Decoding) recipe variants for all H200 configurations and tunes the parameters for optimal performance.

### Changes

**New MTP Recipes Added:**
- `recipes/h200/1k1k/`: 4 new MTP variants (bs128-agg-tp, bs256-1p6d-dep, bs256-1p6d-tp, low-latency-1p9d)
- `recipes/h200/8k1k/`: 6 new MTP variants (bs128-1p1d-dep, bs128-agg-tp, bs16-1p3d, bs4-1p7d, bs64-2p3d, bs8-1p6d)

**MTP Configuration:**
- Added `SGLANG_ENABLE_SPEC_V2` environment variable
- Added speculative decoding parameters (`speculative-algorithm: EAGLE`, `speculative-num-steps`, etc.)
- Tuned batch sizes: MTP uses smaller batch sizes (1/4 to 1/8 of STP) to accommodate draft workers
- Adjusted `mem-fraction-static` to leave memory for MTP draft workers

**Benchmark Improvements:**
- Extended concurrency ranges for better Pareto curve coverage
- Example: `bs128-1p1d-dep` concurrencies expanded from `64x128x256` to `32x64x128x256x512`

## Test Plan

- [x] MTP recipes tested on H200 cluster
- [x] Pareto curves generated comparing MTP vs non-MTP performance
- [x] All configurations show MTP speedup in user latency (TPOT)

## Results

MTP provides significant improvements in user-facing latency across all configurations:
- **agg-tp (1k1k)**: ~20-25% faster user speed at same throughput
- **bs256-1p6d (1k1k)**: ~30-45% faster user speed
- **low-latency-1p9d**: 10-15% improvement in low-latency scenarios
- **8k1k configs**: Consistent rightward shift in Pareto curves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many H200 FP8 deployment recipes covering aggregation, disaggregated, and single-node topologies.
  * Introduced multi-stage (prefill/decode) and single-stage variants with varied model-parallel layouts and batch-size options.
  * Built-in MTP speculative decoding (EAGLE) and tuning knobs for memory, CUDA-graph, and streaming behavior.
  * Included benchmarking configurations for throughput/latency profiles and large context support (1k/8k).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->