### PR TITLE
Add H100 FP8 SGLang Disaggregated Recipes for DSR1

### DIFF
--- a/recipes/h100/1k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
+++ b/recipes/h100/1k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,15 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
-    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
-    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/1k1k/mtp/h100-fp8-1p2d-max-tp-mtp.yaml
+++ b/recipes/h100/1k1k/mtp/h100-fp8-1p2d-max-tp-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p2d-max-tp-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,14 +17,12 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   sglang_config:

--- a/recipes/h100/1k1k/stp/h100-fp8-1p1d-max-dep.yaml
+++ b/recipes/h100/1k1k/stp/h100-fp8-1p1d-max-dep.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/1k1k/stp/h100-fp8-1p2d-max-tp.yaml
+++ b/recipes/h100/1k1k/stp/h100-fp8-1p2d-max-tp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p2d-max-tp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/1k8k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
+++ b/recipes/h100/1k8k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,14 +17,12 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   sglang_config:

--- a/recipes/h100/1k8k/mtp/h100-fp8-1p2d-max-tp-mtp.yaml
+++ b/recipes/h100/1k8k/mtp/h100-fp8-1p2d-max-tp-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p2d-max-tp-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,14 +17,12 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   sglang_config:

--- a/recipes/h100/1k8k/stp/h100-fp8-1p1d-max-dep.yaml
+++ b/recipes/h100/1k8k/stp/h100-fp8-1p1d-max-dep.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/1k8k/stp/h100-fp8-1p2d-max-tp.yaml
+++ b/recipes/h100/1k8k/stp/h100-fp8-1p2d-max-tp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p2d-max-tp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
+++ b/recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,14 +17,12 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   sglang_config:

--- a/recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-tp-mtp.yaml
+++ b/recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-tp-mtp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-tp-mtp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,14 +17,12 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
     SGLANG_ENABLE_SPEC_V2: "1"
 
   sglang_config:

--- a/recipes/h100/8k1k/stp/h100-fp8-1p1d-max-dep.yaml
+++ b/recipes/h100/8k1k/stp/h100-fp8-1p1d-max-dep.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-dep"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:

--- a/recipes/h100/8k1k/stp/h100-fp8-1p1d-max-tp.yaml
+++ b/recipes/h100/8k1k/stp/h100-fp8-1p1d-max-tp.yaml
@@ -2,7 +2,7 @@ name: "h100-fp8-1p1d-max-tp"
 
 model:
   path: "dsfp8"
-  container: "lmsysorg/sglang:v0.5.8-cu130-runtime"
+  container: "lmsysorg/sglang:v0.5.8-cu130"
   precision: "fp8"
 
 resources:
@@ -17,13 +17,11 @@ backend:
 
   # Prefill-specific environment variables
   prefill_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   # Decode-specific environment variables
   decode_environment:
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm_cache-{node_id}"
-    FLASHINFER_WORKSPACE_BASE: "/configs/"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
 
   sglang_config:
     prefill:


### PR DESCRIPTION
## Add H100 FP8 SGLang Disaggregated Recipes for DeepSeek-R1

### Recipes Added

#### 1k1k
Config | Mode | P:D Ratio | Total Nodes | Total GPUs | Prefill | Decode
-- | -- | -- | -- | -- | -- | --
h100-fp8-1p1d-max-dep-mtp | MTP (EAGLE) | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p2d-max-tp-mtp | MTP (EAGLE) | 1P:2D | 6 | 48 | TP-only (tp=16) | TP-only (tp=16)
h100-fp8-1p1d-max-dep | STP | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p2d-max-tp | STP | 1P:2D | 6 | 48 | TP-only (tp=16) | TP-only (tp=16)

#### 8k1k
Config | Mode | P:D Ratio | Total Nodes | Total GPUs | Prefill | Decode
-- | -- | -- | -- | -- | -- | --
h100-fp8-1p1d-max-dep-mtp | MTP (EAGLE) | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p1d-max-tp-mtp | MTP (EAGLE) | 1P:1D | 4 | 32 | TP-only (tp=16) | TP-only (tp=16)
h100-fp8-1p1d-max-dep | STP | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p1d-max-tp | STP | 1P:1D | 4 | 32 | TP-only (tp=16) | TP-only (tp=16)

#### 1k8k
Config | Mode | P:D Ratio | Total Nodes | Total GPUs | Prefill | Decode
-- | -- | -- | -- | -- | -- | --
h100-fp8-1p1d-max-dep-mtp | MTP (EAGLE) | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p2d-max-tp-mtp | MTP (EAGLE) | 1P:2D | 6 | 48 | TP-only (tp=16) | TP-only (tp=16)
h100-fp8-1p1d-max-dep | STP | 1P:1D | 4 | 32 | TP-only (tp=16) | DEP (tp=dp=ep=16)
h100-fp8-1p2d-max-tp | STP | 1P:2D | 6 | 48 | TP-only (tp=16) | TP-only (tp=16)

### Key Settings
- **Container**: `lmsysorg/sglang:v0.5.8-cu130-runtime`
- **Model**: DeepSeek-R1 FP8
- **Backend**: FlashInfer attention
- **Transfer**: NIXL disaggregation
- **Container**: `lmsysorg/sglang:v0.5.8-cu130-runtime`
- **Model**: DeepSeek-R1 FP8
- **Backend**: FlashInfer attention
- **Transfer**: NIXL disaggregation
- **MTP (EAGLE)**: speculative-num-draft-tokens: 3, speculative-num-steps: 2
- **STP**: Single Token Prediction (no speculative decoding)
- **DEP**: Data+Expert Parallelism，tp=16, dp=16, ep=16, enable-dp-attention=true
- **TP-only**: Tensor Parallelism，tp=16, dp=1, ep=1, enable-dp-attention=false
- **1P:1D**: 1 prefill worker (2 nodes) + 1 decode worker (2 nodes)
- **1P:2D**: 1 prefill worker (2 nodes) + 2 decode workers (4 nodes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multiple new H100 FP8 deployment recipes covering various sequence-length, node/worker and GPU configurations with per-phase prefill/decode resource, memory and disaggregation controls, cache/workspace flags, and benchmark presets.

* **New Features**
  * Introduced multi-token prediction (MTP) and speculative decoding (EAGLE) parameters for tuning throughput (speculative steps/top-k/draft tokens) and improved decode/prefill orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->