### PR TITLE
Add shared Pydantic contract package for status API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "jinja2>=3.1.0",
     "marshmallow>=3.20.0",
     "marshmallow-dataclass>=8.6.0",
+    "pydantic>=2.5.0",
     "requests>=2.31.0",
     "rich>=13.0.0",
     "questionary>=2.0.0",
@@ -36,6 +37,8 @@ dev = [
     "pytest-cov>=4.0",
     "ruff>=0.8.0",
     "ty",  # Astral's fast type checker (replaces mypy)
+    "fastapi>=0.109.0",
+    "httpx>=0.27.0",  # Required by FastAPI TestClient
 ]
 
 # =============================================================================
@@ -70,6 +73,7 @@ known-first-party = ["srtctl"]
 # =============================================================================
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"

--- a/src/srtctl/contract/__init__.py
+++ b/src/srtctl/contract/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared API contract between srtslurm (status reporter) and tripwire (status API).
+
+This package defines the canonical Pydantic models and enums for the Status API.
+It has zero internal imports — only depends on pydantic.
+
+Usage (srtslurm side):
+    from srtctl.contract import JobStatus, JobStage, JobCreatePayload, JobUpdatePayload
+
+Usage (tripwire side):
+    from srtctl.contract import JobStatus, JobStage, JobCreatePayload, JobUpdatePayload
+    from srtctl.contract import JobResponse, JobSummary, JobDetail, JobListResponse
+"""
+
+from srtctl.contract.enums import JobStage, JobStatus
+from srtctl.contract.requests import JobCreatePayload, JobUpdatePayload
+from srtctl.contract.responses import JobDetail, JobListResponse, JobResponse, JobSummary
+
+__all__ = [
+    "JobStage",
+    "JobStatus",
+    "JobCreatePayload",
+    "JobUpdatePayload",
+    "JobResponse",
+    "JobSummary",
+    "JobDetail",
+    "JobListResponse",
+]

--- a/src/srtctl/contract/enums.py
+++ b/src/srtctl/contract/enums.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical enum definitions for the Status API contract."""
+
+from enum import Enum
+
+
+class JobStatus(str, Enum):
+    """Job status values.
+
+    These represent the current stage of execution, not readiness.
+    We report when ENTERING a stage, not when it's complete.
+    """
+
+    SUBMITTED = "submitted"
+    STARTING = "starting"
+    WORKERS = "workers"
+    FRONTEND = "frontend"
+    BENCHMARK = "benchmark"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+
+
+class JobStage(str, Enum):
+    """Job execution stages matching do_sweep.py flow."""
+
+    STARTING = "starting"
+    HEAD_INFRASTRUCTURE = "head_infrastructure"
+    WORKERS = "workers"
+    FRONTEND = "frontend"
+    BENCHMARK = "benchmark"
+    CLEANUP = "cleanup"

--- a/src/srtctl/contract/requests.py
+++ b/src/srtctl/contract/requests.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request payload models for the Status API contract."""
+
+from pydantic import BaseModel, Field
+
+
+class JobCreatePayload(BaseModel):
+    """Payload for POST /api/jobs."""
+
+    job_id: str = Field(..., description="Unique job identifier (SLURM job ID)")
+    job_name: str = Field(..., description="Human-readable job name")
+    submitted_at: str = Field(..., description="ISO 8601 submission timestamp")
+    cluster: str | None = Field(None, description="Cluster name")
+    recipe: str | None = Field(None, description="Path to recipe/config file")
+    metadata: dict | None = Field(None, description="Job metadata (may include 'tags' list)")
+
+
+class JobUpdatePayload(BaseModel):
+    """Payload for PUT /api/jobs/{job_id}."""
+
+    status: str = Field(..., description="New job status")
+    updated_at: str = Field(..., description="ISO 8601 update timestamp")
+    stage: str | None = Field(None, description="Current execution stage")
+    message: str | None = Field(None, description="Human-readable status message")
+    started_at: str | None = Field(None, description="ISO 8601 job start timestamp")
+    completed_at: str | None = Field(None, description="ISO 8601 job completion timestamp")
+    exit_code: int | None = Field(None, description="Process exit code")
+    metadata: dict | None = Field(None, description="Additional metadata to merge")

--- a/src/srtctl/contract/responses.py
+++ b/src/srtctl/contract/responses.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response models for the Status API contract."""
+
+from pydantic import BaseModel
+
+
+class JobResponse(BaseModel):
+    """Response model for job create/update operations."""
+
+    job_id: str
+    status: str
+
+
+class JobSummary(BaseModel):
+    """Summary model for job list."""
+
+    job_id: str
+    job_name: str
+    status: str
+    stage: str | None = None
+    cluster: str | None = None
+    submitted_at: str
+    updated_at: str
+
+
+class JobDetail(BaseModel):
+    """Detailed job model with full event history."""
+
+    job_id: str
+    job_name: str
+    status: str
+    stage: str | None = None
+    cluster: str | None = None
+    recipe: str | None = None
+    message: str | None = None
+    submitted_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    updated_at: str
+    exit_code: int | None = None
+    metadata: dict | None = None
+    events: list[dict] | None = None
+
+
+class JobListResponse(BaseModel):
+    """Response model for paginated job list."""
+
+    jobs: list[JobSummary]
+    total: int
+    page: int
+    per_page: int

--- a/tests/mock_status_server.py
+++ b/tests/mock_status_server.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Mock Status API server for integration testing.
+
+Uses shared contract models to validate payloads match the API spec.
+Stores all events in-memory for assertion in tests.
+"""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from srtctl.contract import (
+    JobCreatePayload,
+    JobResponse,
+    JobStatus,
+    JobUpdatePayload,
+)
+
+app = FastAPI()
+
+# In-memory storage for assertions
+jobs: dict[str, dict] = {}
+events: list[dict] = []
+
+
+def reset():
+    """Clear all stored data between tests."""
+    jobs.clear()
+    events.clear()
+
+
+@app.post("/api/jobs", response_model=JobResponse, status_code=201)
+async def create_job(payload: JobCreatePayload):
+    """Create a job record. Validates payload against shared contract."""
+    job_data = payload.model_dump(exclude_none=True)
+    job_data["status"] = JobStatus.SUBMITTED.value
+    jobs[payload.job_id] = job_data
+    events.append({"type": "create", "job_id": payload.job_id, **job_data})
+    return JobResponse(job_id=payload.job_id, status=JobStatus.SUBMITTED.value)
+
+
+@app.put("/api/jobs/{job_id}", response_model=JobResponse)
+async def update_job(job_id: str, payload: JobUpdatePayload):
+    """Update job status. Validates payload against shared contract."""
+    if job_id not in jobs:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    update_data = payload.model_dump(exclude_none=True)
+    jobs[job_id].update(update_data)
+    events.append({"type": "update", "job_id": job_id, **update_data})
+    return JobResponse(job_id=job_id, status=payload.status)
+
+
+def create_test_client() -> TestClient:
+    """Create a fresh TestClient with clean state."""
+    reset()
+    return TestClient(app)

--- a/tests/test_integration_status.py
+++ b/tests/test_integration_status.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests: StatusReporter against mock Status API server.
+
+These tests exercise the full request/response cycle through the shared
+contract models, ensuring srtslurm payloads are accepted by a server
+implementing the same contract.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from srtctl.contract import JobCreatePayload, JobStage, JobStatus, JobUpdatePayload
+from srtctl.core.schema import ReportingConfig, ReportingStatusConfig
+from srtctl.core.status import StatusReporter, create_job_record
+
+import mock_status_server
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_api():
+    """Provide a mock status API that intercepts HTTP requests.
+
+    Patches requests.post/put in srtctl.core.status to route through
+    FastAPI TestClient instead of making real HTTP calls.
+    """
+    client = mock_status_server.create_test_client()
+
+    def route_post(url, json=None, timeout=None):
+        """Route POST requests through TestClient."""
+        # Extract path from URL (e.g., "http://mock:8080/api/jobs" -> "/api/jobs")
+        path = "/" + url.split("/", 3)[-1]
+        response = client.post(path, json=json)
+        return _MockResponse(response.status_code, response.json())
+
+    def route_put(url, json=None, timeout=None):
+        """Route PUT requests through TestClient."""
+        path = "/" + url.split("/", 3)[-1]
+        response = client.put(path, json=json)
+        return _MockResponse(response.status_code, response.json())
+
+    with (
+        patch("srtctl.core.status.requests.post", side_effect=route_post),
+        patch("srtctl.core.status.requests.put", side_effect=route_put),
+    ):
+        yield client
+
+
+class _MockResponse:
+    """Minimal response object matching requests.Response interface."""
+
+    def __init__(self, status_code: int, json_data: dict):
+        self.status_code = status_code
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+
+@pytest.fixture
+def reporting():
+    """Reporting config pointing to mock server."""
+    return ReportingConfig(
+        status=ReportingStatusConfig(endpoint="http://mock:8080")
+    )
+
+
+@pytest.fixture
+def reporter(reporting):
+    """StatusReporter configured for mock server."""
+    return StatusReporter.from_config(reporting, job_id="99999")
+
+
+# ============================================================================
+# Happy Path: Full Lifecycle
+# ============================================================================
+
+
+class TestStatusLifecycleHappyPath:
+    """Test the complete status lifecycle: submit -> start -> stages -> complete."""
+
+    def test_full_lifecycle_produces_correct_events(self, mock_api, reporting, reporter):
+        """Simulates the full orchestrator flow and verifies event sequence."""
+        # Step 0: Create job record (submit.py does this)
+        created = create_job_record(
+            reporting=reporting,
+            job_id="99999",
+            job_name="test-benchmark",
+            cluster="ptyche",
+            recipe="recipes/qwen3-32b/disagg-kv-sglang.yaml",
+            metadata={"tags": ["nightly", "disagg"]},
+        )
+        assert created is True
+
+        # Step 1: report_started (orchestrator.run entry)
+        # We can't call report_started without a real SrtConfig/RuntimeContext,
+        # so we simulate it with a direct report() call
+        result = reporter.report(
+            JobStatus.STARTING, JobStage.STARTING, "Job started on gb200-01"
+        )
+        assert result is True
+
+        # Step 2: Head infrastructure
+        result = reporter.report(
+            JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting head infrastructure"
+        )
+        assert result is True
+
+        # Step 3: Workers
+        result = reporter.report(
+            JobStatus.WORKERS, JobStage.WORKERS, "Starting workers"
+        )
+        assert result is True
+
+        # Step 4: Frontend
+        result = reporter.report(
+            JobStatus.FRONTEND, JobStage.FRONTEND, "Starting frontend"
+        )
+        assert result is True
+
+        # Step 5: Benchmark
+        result = reporter.report(
+            JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running benchmark"
+        )
+        assert result is True
+
+        # Step 6: Completed
+        result = reporter.report_completed(exit_code=0)
+        assert result is True
+
+        # Verify event sequence
+        events = mock_status_server.events
+        assert len(events) == 7  # 1 create + 6 updates
+
+        # Verify create event
+        assert events[0]["type"] == "create"
+        assert events[0]["job_id"] == "99999"
+        assert events[0]["job_name"] == "test-benchmark"
+        assert events[0]["cluster"] == "ptyche"
+        assert events[0]["recipe"] == "recipes/qwen3-32b/disagg-kv-sglang.yaml"
+        assert events[0]["metadata"]["tags"] == ["nightly", "disagg"]
+
+        # Verify status progression
+        update_statuses = [e["status"] for e in events[1:]]
+        assert update_statuses == [
+            "starting",
+            "starting",
+            "workers",
+            "frontend",
+            "benchmark",
+            "completed",
+        ]
+
+        # Verify stage progression
+        update_stages = [e.get("stage") for e in events[1:]]
+        assert update_stages == [
+            "starting",
+            "head_infrastructure",
+            "workers",
+            "frontend",
+            "benchmark",
+            "cleanup",
+        ]
+
+        # Verify final state
+        job = mock_status_server.jobs["99999"]
+        assert job["status"] == "completed"
+        assert job["exit_code"] == 0
+        assert "completed_at" in job
+
+    def test_lifecycle_with_failure(self, mock_api, reporting, reporter):
+        """Simulates a failure during workers stage."""
+        # Create job
+        create_job_record(
+            reporting=reporting,
+            job_id="99999",
+            job_name="failing-benchmark",
+        )
+
+        # Start
+        reporter.report(JobStatus.STARTING, JobStage.STARTING, "Job started")
+        reporter.report(JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting infra")
+
+        # Workers stage
+        reporter.report(JobStatus.WORKERS, JobStage.WORKERS, "Starting workers")
+
+        # Simulate health check failure (this is what benchmark_stage.py does)
+        reporter.report(JobStatus.FAILED, JobStage.BENCHMARK, "Workers failed health check")
+
+        # Completed with failure
+        reporter.report_completed(exit_code=1)
+
+        # Verify failure events
+        events = mock_status_server.events
+        update_events = [e for e in events if e["type"] == "update"]
+
+        # Last update should be the completed call
+        last = update_events[-1]
+        assert last["status"] == "failed"
+        assert last["exit_code"] == 1
+
+        # Final job state
+        job = mock_status_server.jobs["99999"]
+        assert job["status"] == "failed"
+        assert job["exit_code"] == 1
+
+
+# ============================================================================
+# Contract Validation: Payloads are accepted by the server
+# ============================================================================
+
+
+class TestContractValidation:
+    """Verify that srtslurm-generated payloads pass server-side Pydantic validation."""
+
+    def test_create_payload_with_all_fields(self, mock_api, reporting):
+        """Server accepts a fully-populated create payload."""
+        result = create_job_record(
+            reporting=reporting,
+            job_id="11111",
+            job_name="full-payload-test",
+            cluster="lyris",
+            recipe="recipes/llama/agg.yaml",
+            metadata={
+                "tags": ["ci", "smoke"],
+                "commit_sha": "abc123",
+            },
+        )
+        assert result is True
+        assert mock_status_server.jobs["11111"]["cluster"] == "lyris"
+
+    def test_create_payload_minimal(self, mock_api, reporting):
+        """Server accepts a minimal create payload (only required fields)."""
+        result = create_job_record(
+            reporting=reporting,
+            job_id="22222",
+            job_name="minimal-test",
+        )
+        assert result is True
+        assert "22222" in mock_status_server.jobs
+
+    def test_update_payload_with_metadata(self, mock_api, reporting, reporter):
+        """Server accepts update payload with metadata dict."""
+        create_job_record(
+            reporting=reporting,
+            job_id="99999",
+            job_name="metadata-test",
+        )
+
+        result = reporter.report(
+            JobStatus.STARTING,
+            JobStage.STARTING,
+            "Testing metadata",
+        )
+        assert result is True
+
+    def test_update_payload_with_exit_code_zero(self, mock_api, reporting, reporter):
+        """Server accepts exit_code=0 (falsy but valid)."""
+        create_job_record(
+            reporting=reporting,
+            job_id="99999",
+            job_name="exit-code-test",
+        )
+
+        result = reporter.report_completed(exit_code=0)
+        assert result is True
+
+        job = mock_status_server.jobs["99999"]
+        assert job["exit_code"] == 0
+
+    def test_update_nonexistent_job_returns_false(self, mock_api, reporter):
+        """Updating a job that doesn't exist returns False (404 from server)."""
+        # Don't create the job first
+        result = reporter.report(JobStatus.STARTING, JobStage.STARTING)
+        assert result is False
+
+
+# ============================================================================
+# Pydantic Model Compatibility
+# ============================================================================
+
+
+class TestModelCompatibility:
+    """Ensure contract models serialize/deserialize correctly across boundary."""
+
+    def test_job_create_payload_round_trip(self):
+        """JobCreatePayload serializes to JSON matching server expectations."""
+        payload = JobCreatePayload(
+            job_id="12345",
+            job_name="roundtrip-test",
+            submitted_at="2025-01-26T10:00:00Z",
+            cluster="bia",
+            metadata={"tags": ["test"]},
+        )
+
+        dumped = payload.model_dump(exclude_none=True)
+
+        # Verify it can be parsed back
+        parsed = JobCreatePayload.model_validate(dumped)
+        assert parsed.job_id == "12345"
+        assert parsed.cluster == "bia"
+        assert parsed.metadata == {"tags": ["test"]}
+
+    def test_job_update_payload_round_trip(self):
+        """JobUpdatePayload serializes to JSON matching server expectations."""
+        payload = JobUpdatePayload(
+            status="workers",
+            updated_at="2025-01-26T10:05:00Z",
+            stage="workers",
+            message="Starting 6 workers",
+            exit_code=None,
+        )
+
+        dumped = payload.model_dump(exclude_none=True)
+
+        # None fields should be excluded
+        assert "exit_code" not in dumped
+        assert dumped["status"] == "workers"
+        assert dumped["stage"] == "workers"
+
+        # Verify round-trip
+        parsed = JobUpdatePayload.model_validate(dumped)
+        assert parsed.status == "workers"
+        assert parsed.exit_code is None
+
+    def test_enum_values_match_between_contract_and_status(self):
+        """Contract enums produce same string values used in StatusReporter."""
+        # These are the exact values the orchestrator passes
+        assert JobStatus.STARTING.value == "starting"
+        assert JobStatus.WORKERS.value == "workers"
+        assert JobStatus.FRONTEND.value == "frontend"
+        assert JobStatus.BENCHMARK.value == "benchmark"
+        assert JobStatus.COMPLETED.value == "completed"
+        assert JobStatus.FAILED.value == "failed"
+
+        assert JobStage.STARTING.value == "starting"
+        assert JobStage.HEAD_INFRASTRUCTURE.value == "head_infrastructure"
+        assert JobStage.WORKERS.value == "workers"
+        assert JobStage.FRONTEND.value == "frontend"
+        assert JobStage.BENCHMARK.value == "benchmark"
+        assert JobStage.CLEANUP.value == "cleanup"

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -7,12 +7,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from srtctl.contract import JobCreatePayload, JobStage, JobStatus, JobUpdatePayload
 from srtctl.core.schema import ReportingConfig, ReportingStatusConfig
 from srtctl.core.status import (
-    JobCreatePayload,
-    JobStage,
-    JobStatus,
-    JobUpdatePayload,
     StatusReporter,
     create_job_record,
 )
@@ -168,29 +165,29 @@ class TestStatusReporterCompleted:
 
 
 # ============================================================================
-# Payload Dataclass Tests
+# Payload Model Tests
 # ============================================================================
 
 
 class TestJobCreatePayload:
-    """Test JobCreatePayload dataclass."""
+    """Test JobCreatePayload Pydantic model."""
 
-    def test_to_dict_includes_required_fields(self):
-        """to_dict includes all required fields."""
+    def test_model_dump_includes_required_fields(self):
+        """model_dump includes all required fields."""
         payload = JobCreatePayload(
             job_id="12345",
             job_name="test-job",
             submitted_at="2025-01-26T10:00:00Z",
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert result["job_id"] == "12345"
         assert result["job_name"] == "test-job"
         assert result["submitted_at"] == "2025-01-26T10:00:00Z"
 
-    def test_to_dict_excludes_none_values(self):
-        """to_dict excludes fields with None values."""
+    def test_model_dump_excludes_none_values(self):
+        """model_dump(exclude_none=True) excludes fields with None values."""
         payload = JobCreatePayload(
             job_id="12345",
             job_name="test-job",
@@ -200,14 +197,14 @@ class TestJobCreatePayload:
             metadata=None,
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert "cluster" not in result
         assert "recipe" not in result
         assert "metadata" not in result
 
-    def test_to_dict_includes_optional_fields_when_set(self):
-        """to_dict includes optional fields when they have values."""
+    def test_model_dump_includes_optional_fields_when_set(self):
+        """model_dump includes optional fields when they have values."""
         payload = JobCreatePayload(
             job_id="12345",
             job_name="test-job",
@@ -217,7 +214,7 @@ class TestJobCreatePayload:
             metadata={"key": "value"},
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert result["cluster"] == "gpu-cluster"
         assert result["recipe"] == "configs/test.yaml"
@@ -225,22 +222,22 @@ class TestJobCreatePayload:
 
 
 class TestJobUpdatePayload:
-    """Test JobUpdatePayload dataclass."""
+    """Test JobUpdatePayload Pydantic model."""
 
-    def test_to_dict_includes_required_fields(self):
-        """to_dict includes required fields."""
+    def test_model_dump_includes_required_fields(self):
+        """model_dump includes required fields."""
         payload = JobUpdatePayload(
             status="starting",
             updated_at="2025-01-26T10:00:00Z",
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert result["status"] == "starting"
         assert result["updated_at"] == "2025-01-26T10:00:00Z"
 
-    def test_to_dict_excludes_none_values(self):
-        """to_dict excludes fields with None values."""
+    def test_model_dump_excludes_none_values(self):
+        """model_dump(exclude_none=True) excludes fields with None values."""
         payload = JobUpdatePayload(
             status="starting",
             updated_at="2025-01-26T10:00:00Z",
@@ -248,20 +245,20 @@ class TestJobUpdatePayload:
             message=None,
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert "stage" not in result
         assert "message" not in result
 
-    def test_to_dict_includes_exit_code_when_set(self):
-        """to_dict includes exit_code when set."""
+    def test_model_dump_includes_exit_code_when_set(self):
+        """model_dump includes exit_code when set."""
         payload = JobUpdatePayload(
             status="completed",
             updated_at="2025-01-26T10:00:00Z",
             exit_code=0,
         )
 
-        result = payload.to_dict()
+        result = payload.model_dump(exclude_none=True)
 
         assert result["exit_code"] == 0
 


### PR DESCRIPTION
## Summary
- Create `srtctl.contract` package with canonical Pydantic models and enums for the Status API
- Migrate `JobCreatePayload`/`JobUpdatePayload` from dataclasses to Pydantic BaseModels (`model_dump` replaces `to_dict`)
- Add mock status server and 10 integration tests validating the full request/response lifecycle
- Remove dead `TestCIConfigs` tests (referenced non-existent `ci/agg.yaml` and `ci/disagg.yaml`)

## Test plan
- [x] `uv run pytest tests/test_status.py -v` — 26 existing unit tests pass with Pydantic migration
- [x] `uv run pytest tests/test_integration_status.py -v` — 10 new integration tests pass
- [x] `uv run pytest tests/ -v` — full suite: 230 passed, 0 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Formalized Status API contract with structured request and response models for job management
  * Defined job lifecycle stages and status tracking with standardized values
  * Enhanced validation for job creation and status updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->