### PR TITLE
add trtllm agg config option

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -57,6 +57,7 @@ class TRTLLMProtocol:
 
     prefill_environment: dict[str, str] = field(default_factory=dict)
     decode_environment: dict[str, str] = field(default_factory=dict)
+    aggregated_environment: dict[str, str] = field(default_factory=dict)
 
     trtllm_config: TRTLLMServerConfig | None = None
 
@@ -86,7 +87,7 @@ class TRTLLMProtocol:
         elif mode == "decode":
             return dict(self.trtllm_config.decode or {})
         elif mode == "agg":
-            raise ValueError("Aggregated mode is not supported for TRTLLM")
+            return dict(self.trtllm_config.aggregated or {})
         return {}
 
     def get_environment_for_mode(self, mode: WorkerMode) -> dict[str, str]:
@@ -97,7 +98,7 @@ class TRTLLMProtocol:
         elif mode == "decode":
             return {**self.decode_environment, "TRTLLM_EPLB_SHM_NAME": eplb_prefix}
         elif mode == "agg":
-            raise ValueError("Aggregated mode is not supported for TRTLLM")
+            return {**self.aggregated_environment, "TRTLLM_EPLB_SHM_NAME": eplb_prefix}
         return {}
 
     def get_process_environment(self, process: "Process") -> dict[str, str]:
@@ -181,12 +182,17 @@ class TRTLLMProtocol:
             str(container_model_path),
             "--served-model-name",
             runtime.model_path.name,
-            "--disaggregation-mode",
-            mode,
+        ]
+
+        # Only add disaggregation mode for prefill/decode, not for agg
+        if mode != "agg":
+            cmd.extend(["--disaggregation-mode", mode])
+
+        cmd.extend([
             "--extra-engine-args",
             str(container_config_path),
             "--request-plane",
             "nats",
-        ]
+        ])
 
         return cmd


### PR DESCRIPTION
small changes to allow agg benchmarking; can pass in trtllm configs formatted like

```
...
backend:
  type: trtllm

  aggregated_environment:
    TLLM_LOG_LEVEL: "INFO"
    TRTLLM_SERVER_DISABLE_GC: "1"
    ...

  trtllm_config:
    aggregated:
      allreduce_strategy: MNNVL
      max_num_tokens: 8192
      ...
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added aggregated mode support for TRTLLM backend with enhanced environment variable handling.
  * Improved command-line flag handling for aggregated mode deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->