### PR TITLE
Add setup script to fix deepep timeouts + add deepgemm fast warmup

### DIFF
--- a/configs/fix-timeouts.sh
+++ b/configs/fix-timeouts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+BRANCH="fastdg"
+
+# v0.5.8 + cherry-pick https://github.com/sgl-project/sglang/pull/18111
+# Make sure to set SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
+cd /sgl-workspace/sglang
+git remote remove origin
+git remote add origin https://github.com/trevor-m/sglang.git
+git fetch origin
+git checkout origin/${BRANCH}
+
+# Increase device timeout from 100s -> 1000s
+cd /sgl-workspace/DeepEP
+sed -i 's/#define NUM_TIMEOUT_CYCLES 200000000000ull/#define NUM_TIMEOUT_CYCLES 2000000000000ull/' csrc/kernels/configs.cuh
+TORCH_CUDA_ARCH_LIST="10.0;10.3" MAX_JOBS=$(nproc) pip install --force-reinstall --no-build-isolation .
+


### PR DESCRIPTION
1. Switches to sglang branch which is v0.5.8 with https://github.com/sgl-project/sglang/pull/18111 cherry-picked on top of it. Remember to set `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1` in your script.
2. Patch DeepEP to increase device timeout from 100s ->1000s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated configuration script to streamline dependency installation and system configuration updates.

* **Bug Fixes**
  * Increased device timeout limits to improve stability for long-running operations and reduce timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->