### PR TITLE
Add 1k1k STP and MTP disagg H100 configs

### DIFF
--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen1_dep16_batch32_eplb0_mtp2.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen1_dep16_batch32_eplb0_mtp2.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen1dep16_batch32_eplb0_mtp2_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen1_dep16_batch64_eplb0_mtp1.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen1_dep16_batch64_eplb0_mtp1.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen1dep16_batch64_eplb0_mtp1_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_dep16_batch4_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_dep16_batch4_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3dep16_batch4_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch128_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch128_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch128_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch16_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch16_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch16_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch1_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch1_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch1_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch2_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch2_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch2_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch32_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch32_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/mtp/ctx1_gen3_tep16_batch8_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_1k1k_ctx1dep16_gen3tep16_batch8_eplb0_mtp3_chunked_false
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch16_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3dep16_batch16_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch32_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3dep16_batch32_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch4_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch4_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3dep16_batch4_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch8_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_dep16_batch8_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3dep16_batch8_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch16_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3tep16_batch16_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch1_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch1_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3tep16_batch1_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch2_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch2_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3tep16_batch2_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch8_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx1_gen3_tep16_batch8_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx1dep16_gen3tep16_batch8_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/1k1k/stp/ctx2_gen1_dep16_batch256_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/1k1k/stp/ctx2_gen1_dep16_batch256_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: ctx2dep16_gen1dep16_batch256_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen1_dep16_batch4_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen1_dep16_batch4_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen1dep16_batch4_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen2_tep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen2_tep16_batch32_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen2tep16_batch32_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch1_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch1_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen3tep16_batch1_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch2_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch2_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen3tep16_batch2_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx1_gen3_tep16_batch8_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen3tep16_batch8_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/mtp/ctx2_gen1_dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/mtp/ctx2_gen1_dep16_batch8_eplb0_mtp3.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx2dep16_gen1dep16_batch8_eplb0_mtp3
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen2_tep16_batch64_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen2_tep16_batch64_eplb0_mtp0.yaml
@@ -4,7 +4,7 @@ name: "h100_8k1k_ctx1dep16_gen2tep16_batch64_eplb0_mtp0"
 
 model:
   path: "DeepSeek-R1-0528"
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: "fp8"
 
 resources:

--- a/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch1_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch1_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx1dep16_gen3tep16_batch1_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100

--- a/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch2_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch2_eplb0_mtp0.yaml
@@ -4,7 +4,7 @@ name: "h100_8k1k_ctx1dep16_gen3tep16_batch2_eplb0_mtp0"
 
 model:
   path: "DeepSeek-R1-0528"
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: "fp8"
 
 resources:

--- a/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch8_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/stp/ctx1_gen3_tep16_batch8_eplb0_mtp0.yaml
@@ -4,7 +4,7 @@ name: "h100_8k1k_ctx1dep16_gen3tep16_batch8_eplb0_mtp0"
 
 model:
   path: "DeepSeek-R1-0528"
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: "fp8"
 
 resources:

--- a/recipes/trtllm/h100-fp8/8k1k/stp/ctx2_gen1_dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/trtllm/h100-fp8/8k1k/stp/ctx2_gen1_dep16_batch16_eplb0_mtp0.yaml
@@ -1,7 +1,7 @@
 name: h100_8k1k_ctx2dep16_gen1dep16_batch16_eplb0_mtp0
 model:
   path: DeepSeek-R1-0528
-  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1"
+  container: "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3"
   precision: fp8
 resources:
   gpu_type: h100


### PR DESCRIPTION
Add 18 verified Pareto-optimal H100 FP8 disaggregated TensorRT-LLM configurations for 1024/1024 ISL/OSL
9 STP configs covering concurrencies: 6, 9, 30, 60, 231, 462, 924, 1845, 4916
9 MTP configs covering concurrencies: 6, 9, 30, 60, 117, 231, 615, 616, 1229
