### PR TITLE
Increase NATS/etcd timeout to 300s for cold container imports

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -130,13 +130,14 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
             critical=True,
         )
 
+        # 300s timeout to handle slow container imports on first run
         logger.info("Waiting for NATS (port 4222) on %s...", infra_node)
-        if not wait_for_port(infra_node, 4222, timeout=60):
+        if not wait_for_port(infra_node, 4222, timeout=300):
             raise RuntimeError("NATS failed to start")
         logger.info("NATS is ready")
 
         logger.info("Waiting for etcd (port 2379) on %s...", infra_node)
-        if not wait_for_port(infra_node, 2379, timeout=60):
+        if not wait_for_port(infra_node, 2379, timeout=300):
             raise RuntimeError("etcd failed to start")
         logger.info("etcd is ready")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended startup timeout from 60 to 300 seconds, providing additional time for services to become ready during initial startup on slower systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->