### PR TITLE
bugfix: Fix port conflict

### DIFF
--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -265,10 +265,8 @@ class SGLangProtocol:
             ]
         )
 
-        # Only pass --port when using sglang.launch_server (not dynamo.sglang)
-        # dynamo.sglang uses DYN_SYSTEM_PORT env var instead
-        if use_sglang:
-            cmd.extend(["--port", str(process.http_port)])
+        # Always pass --port when using sglang.launch_server or dynamo.sglang
+        cmd.extend(["--port", str(process.http_port)])
 
         # Add disaggregation mode for prefill/decode workers (both dynamo and sglang frontend)
         if mode != "agg":

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -66,7 +66,7 @@ class NodePortAllocator:
         if node not in self._http_ports:
             self._http_ports[node] = self.base_http_port
         port = self._http_ports[node]
-        self._http_ports[node] += 1
+        self._http_ports[node] += 1000
         return port
 
     def next_bootstrap_port(self, node: str) -> int:


### PR DESCRIPTION
When using 2 prefill workers with DEP4 in SGLang, they will be assigned to the same node and use the same port, leading to port conflict.
```
ValueError: port_base at 30234 is not available in 30 seconds. port_base is used by a process already.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Revised port flag handling logic to ensure consistent HTTP port exposure for worker processes.
  * Modified HTTP port allocation spacing increments for multi-worker node configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->