### PR TITLE
Fix ulimit error in containers

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -42,7 +42,7 @@ curl -s "${ENDPOINT}/v1/chat/completions" \
     }" | head -c 200
 echo ""
 
-ulimit -n 65536
+ulimit -n 65536 2>/dev/null || true  # May fail in containers without CAP_SYS_RESOURCE
 
 # Benchmark
 result_dir="/logs/sa-bench_isl_${ISL}_osl_${OSL}"


### PR DESCRIPTION
## Summary
- Make ulimit call non-fatal since containers typically don't have CAP_SYS_RESOURCE capability to modify resource limits

## Test plan
- [x] Run benchmark in container that lacks CAP_SYS_RESOURCE
- [ ] Verify benchmark completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced benchmarking script robustness in containerized environments where resource limit operations may be restricted, preventing script failures in such scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->