### PR TITLE
Support multiple status API endpoints for simultaneous reporting

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -57,6 +57,7 @@ class ReportingStatusConfig:
     """Status reporting configuration."""
 
     endpoint: str | None = None
+    endpoints: list[str] | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -11,8 +11,49 @@ from srtctl.contract import JobCreatePayload, JobStage, JobStatus, JobUpdatePayl
 from srtctl.core.schema import ReportingConfig, ReportingStatusConfig
 from srtctl.core.status import (
     StatusReporter,
+    _resolve_endpoints,
     create_job_record,
 )
+
+
+# ============================================================================
+# _resolve_endpoints Tests
+# ============================================================================
+
+
+class TestResolveEndpoints:
+    """Test _resolve_endpoints() helper function."""
+
+    def test_returns_empty_tuple_for_none(self):
+        assert _resolve_endpoints(None) == ()
+
+    def test_returns_single_endpoint(self):
+        status = ReportingStatusConfig(endpoint="https://a.com")
+        assert _resolve_endpoints(status) == ("https://a.com",)
+
+    def test_returns_endpoints_list(self):
+        status = ReportingStatusConfig(endpoints=["https://a.com", "https://b.com"])
+        assert _resolve_endpoints(status) == ("https://a.com", "https://b.com")
+
+    def test_merges_endpoint_and_endpoints(self):
+        status = ReportingStatusConfig(endpoint="https://a.com", endpoints=["https://b.com"])
+        assert _resolve_endpoints(status) == ("https://a.com", "https://b.com")
+
+    def test_deduplicates(self):
+        status = ReportingStatusConfig(endpoint="https://a.com", endpoints=["https://a.com", "https://b.com"])
+        assert _resolve_endpoints(status) == ("https://a.com", "https://b.com")
+
+    def test_strips_trailing_slashes(self):
+        status = ReportingStatusConfig(endpoint="https://a.com/", endpoints=["https://b.com/"])
+        assert _resolve_endpoints(status) == ("https://a.com", "https://b.com")
+
+    def test_deduplicates_after_stripping_slashes(self):
+        status = ReportingStatusConfig(endpoint="https://a.com/", endpoints=["https://a.com"])
+        assert _resolve_endpoints(status) == ("https://a.com",)
+
+    def test_empty_endpoint_and_none_endpoints(self):
+        status = ReportingStatusConfig(endpoint=None, endpoints=None)
+        assert _resolve_endpoints(status) == ()
 
 
 # ============================================================================
@@ -33,7 +74,7 @@ class TestStatusReporterFromConfig:
 
         assert reporter.enabled is True
         assert reporter.job_id == "12345"
-        assert reporter.api_endpoint == "https://status.example.com"
+        assert reporter.api_endpoints == ("https://status.example.com",)
 
     def test_creates_disabled_reporter_without_endpoint(self):
         """Reporter is disabled when no endpoint configured."""
@@ -42,14 +83,14 @@ class TestStatusReporterFromConfig:
         reporter = StatusReporter.from_config(reporting, job_id="12345")
 
         assert reporter.enabled is False
-        assert reporter.api_endpoint is None
+        assert reporter.api_endpoints == ()
 
     def test_creates_disabled_reporter_with_none_reporting(self):
         """Reporter is disabled when reporting config is None."""
         reporter = StatusReporter.from_config(None, job_id="12345")
 
         assert reporter.enabled is False
-        assert reporter.api_endpoint is None
+        assert reporter.api_endpoints == ()
 
     def test_creates_disabled_reporter_with_none_status(self):
         """Reporter is disabled when status config is None."""
@@ -67,7 +108,31 @@ class TestStatusReporterFromConfig:
 
         reporter = StatusReporter.from_config(reporting, job_id="12345")
 
-        assert reporter.api_endpoint == "https://status.example.com"
+        assert reporter.api_endpoints == ("https://status.example.com",)
+
+    def test_creates_reporter_with_endpoints_list(self):
+        """Reporter uses endpoints list when provided."""
+        reporting = ReportingConfig(
+            status=ReportingStatusConfig(endpoints=["https://a.com", "https://b.com"])
+        )
+
+        reporter = StatusReporter.from_config(reporting, job_id="12345")
+
+        assert reporter.enabled is True
+        assert reporter.api_endpoints == ("https://a.com", "https://b.com")
+
+    def test_creates_reporter_with_both_endpoint_and_endpoints(self):
+        """Reporter merges endpoint and endpoints, deduplicating."""
+        reporting = ReportingConfig(
+            status=ReportingStatusConfig(
+                endpoint="https://a.com",
+                endpoints=["https://b.com"],
+            )
+        )
+
+        reporter = StatusReporter.from_config(reporting, job_id="12345")
+
+        assert reporter.api_endpoints == ("https://a.com", "https://b.com")
 
 
 class TestStatusReporterReport:
@@ -75,7 +140,7 @@ class TestStatusReporterReport:
 
     def test_returns_false_when_disabled(self):
         """Report returns False when reporter is disabled."""
-        reporter = StatusReporter(job_id="12345", api_endpoint=None)
+        reporter = StatusReporter(job_id="12345", api_endpoints=())
 
         result = reporter.report(JobStatus.STARTING)
 
@@ -85,7 +150,7 @@ class TestStatusReporterReport:
     def test_sends_put_request_to_correct_url(self, mock_put):
         """Report sends PUT request to /api/jobs/{job_id}."""
         mock_put.return_value = MagicMock(status_code=200)
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         reporter.report(JobStatus.WORKERS, stage=JobStage.WORKERS)
 
@@ -97,7 +162,7 @@ class TestStatusReporterReport:
     def test_returns_true_on_success(self, mock_put):
         """Report returns True on HTTP 200."""
         mock_put.return_value = MagicMock(status_code=200)
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         result = reporter.report(JobStatus.STARTING)
 
@@ -107,7 +172,7 @@ class TestStatusReporterReport:
     def test_returns_false_on_http_error(self, mock_put):
         """Report returns False on non-200 status."""
         mock_put.return_value = MagicMock(status_code=500)
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         result = reporter.report(JobStatus.STARTING)
 
@@ -119,11 +184,41 @@ class TestStatusReporterReport:
         import requests
 
         mock_put.side_effect = requests.exceptions.ConnectionError("Network error")
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         result = reporter.report(JobStatus.STARTING)
 
         assert result is False
+
+    @patch("srtctl.core.status.requests.put")
+    def test_sends_to_all_endpoints(self, mock_put):
+        """Report sends PUT to every configured endpoint."""
+        mock_put.return_value = MagicMock(status_code=200)
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://a.com", "https://b.com"))
+
+        result = reporter.report(JobStatus.STARTING)
+
+        assert result is True
+        assert mock_put.call_count == 2
+        urls = [call.args[0] for call in mock_put.call_args_list]
+        assert "https://a.com/api/jobs/12345" in urls
+        assert "https://b.com/api/jobs/12345" in urls
+
+    @patch("srtctl.core.status.requests.put")
+    def test_one_endpoint_failing_does_not_block_others(self, mock_put):
+        """If first endpoint fails, second still gets called and result is True."""
+        import requests as req
+
+        mock_put.side_effect = [
+            req.exceptions.ConnectionError("Network error"),
+            MagicMock(status_code=200),
+        ]
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://a.com", "https://b.com"))
+
+        result = reporter.report(JobStatus.STARTING)
+
+        assert result is True
+        assert mock_put.call_count == 2
 
 
 class TestStatusReporterCompleted:
@@ -131,7 +226,7 @@ class TestStatusReporterCompleted:
 
     def test_returns_false_when_disabled(self):
         """report_completed returns False when disabled."""
-        reporter = StatusReporter(job_id="12345", api_endpoint=None)
+        reporter = StatusReporter(job_id="12345", api_endpoints=())
 
         result = reporter.report_completed(exit_code=0)
 
@@ -141,7 +236,7 @@ class TestStatusReporterCompleted:
     def test_reports_completed_status_on_success(self, mock_put):
         """Exit code 0 reports COMPLETED status."""
         mock_put.return_value = MagicMock(status_code=200)
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         reporter.report_completed(exit_code=0)
 
@@ -154,7 +249,7 @@ class TestStatusReporterCompleted:
     def test_reports_failed_status_on_nonzero_exit(self, mock_put):
         """Non-zero exit code reports FAILED status."""
         mock_put.return_value = MagicMock(status_code=200)
-        reporter = StatusReporter(job_id="12345", api_endpoint="https://status.example.com")
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://status.example.com",))
 
         reporter.report_completed(exit_code=1)
 
@@ -162,6 +257,17 @@ class TestStatusReporterCompleted:
         payload = call_args[1]["json"]
         assert payload["status"] == "failed"
         assert payload["exit_code"] == 1
+
+    @patch("srtctl.core.status.requests.put")
+    def test_report_completed_sends_to_all_endpoints(self, mock_put):
+        """report_completed sends to all configured endpoints."""
+        mock_put.return_value = MagicMock(status_code=200)
+        reporter = StatusReporter(job_id="12345", api_endpoints=("https://a.com", "https://b.com"))
+
+        result = reporter.report_completed(exit_code=0)
+
+        assert result is True
+        assert mock_put.call_count == 2
 
 
 # ============================================================================
@@ -344,6 +450,48 @@ class TestCreateJobRecord:
         )
 
         assert result is False
+
+    @patch("srtctl.core.status.requests.post")
+    def test_sends_to_all_endpoints(self, mock_post):
+        """Sends POST to every configured endpoint."""
+        mock_post.return_value = MagicMock(status_code=201)
+        reporting = ReportingConfig(
+            status=ReportingStatusConfig(endpoints=["https://a.com", "https://b.com"])
+        )
+
+        result = create_job_record(
+            reporting=reporting,
+            job_id="12345",
+            job_name="test-job",
+        )
+
+        assert result is True
+        assert mock_post.call_count == 2
+        urls = [call.args[0] for call in mock_post.call_args_list]
+        assert "https://a.com/api/jobs" in urls
+        assert "https://b.com/api/jobs" in urls
+
+    @patch("srtctl.core.status.requests.post")
+    def test_one_endpoint_failing_does_not_block_others(self, mock_post):
+        """If first endpoint fails, second still gets called."""
+        import requests as req
+
+        mock_post.side_effect = [
+            req.exceptions.ConnectionError("Network error"),
+            MagicMock(status_code=201),
+        ]
+        reporting = ReportingConfig(
+            status=ReportingStatusConfig(endpoints=["https://a.com", "https://b.com"])
+        )
+
+        result = create_job_record(
+            reporting=reporting,
+            job_id="12345",
+            job_name="test-job",
+        )
+
+        assert result is True
+        assert mock_post.call_count == 2
 
 
 # ============================================================================


### PR DESCRIPTION
Allow status reporter to send to multiple dashboards (e.g., production and dev) by adding an `endpoints` list field alongside the existing `endpoint` string. Both are merged and deduplicated at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Status reporting now supports multiple endpoints for status updates, with automatic deduplication and trailing slash normalization. Both single and multiple endpoints can be configured together for flexible integration.

* **Tests**
  * Enhanced test coverage for multi-endpoint status reporting, including endpoint normalization, deduplication, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->