### PR TITLE
[sa-submission-q1-2026] Add numa core binding for all gb200 and gb300 configs

### DIFF
--- a/recipes/gb200-fp4/1k1k/1p2d-mtp.yaml
+++ b/recipes/gb200-fp4/1k1k/1p2d-mtp.yaml
@@ -79,6 +79,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1
@@ -105,6 +106,7 @@ backend:
       enable-symm-mem: true
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1

--- a/recipes/gb200-fp4/1k1k/low-latency.yaml
+++ b/recipes/gb200-fp4/1k1k/low-latency.yaml
@@ -83,6 +83,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
     decode:
       disaggregation-mode: "decode"
@@ -107,6 +108,7 @@ backend:
       fp4-gemm-backend: "flashinfer_trtllm"
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
 benchmark:
   type: "sa-bench"

--- a/recipes/gb200-fp4/1k1k/max-tpt-mtp.yaml
+++ b/recipes/gb200-fp4/1k1k/max-tpt-mtp.yaml
@@ -117,6 +117,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-single-batch-overlap: true
 
       # Parallelism
@@ -184,6 +185,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-single-batch-overlap: true
 
       # Parallelism

--- a/recipes/gb200-fp4/1k1k/max-tpt.yaml
+++ b/recipes/gb200-fp4/1k1k/max-tpt.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 
@@ -167,6 +168,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: nixl
       fp4-gemm-backend: "flashinfer_cutlass"
 

--- a/recipes/gb200-fp4/1k1k/mid-curve.yaml
+++ b/recipes/gb200-fp4/1k1k/mid-curve.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 
@@ -166,6 +167,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: nixl
       fp4-gemm-backend: "flashinfer_cutlass"
 

--- a/recipes/gb200-fp4/1k8k/low-latency.yaml
+++ b/recipes/gb200-fp4/1k8k/low-latency.yaml
@@ -79,6 +79,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 
@@ -102,6 +103,7 @@ backend:
       scheduler-recv-interval: 10
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb200-fp4/1k8k/max-tpt.yaml
+++ b/recipes/gb200-fp4/1k8k/max-tpt.yaml
@@ -107,6 +107,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism
@@ -234,6 +235,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism

--- a/recipes/gb200-fp4/1k8k/mid-curve.yaml
+++ b/recipes/gb200-fp4/1k8k/mid-curve.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism
@@ -232,6 +233,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism

--- a/recipes/gb200-fp4/8k1k/low-latency.yaml
+++ b/recipes/gb200-fp4/8k1k/low-latency.yaml
@@ -83,6 +83,7 @@ backend:
       fp4-gemm-backend: "flashinfer_trtllm"
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       enable-dp-attention: false
  
     decode:
@@ -108,6 +109,7 @@ backend:
       fp4-gemm-backend: "flashinfer_trtllm"
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       enable-dp-attention: false
 
 benchmark:

--- a/recipes/gb200-fp4/8k1k/max-tpt.yaml
+++ b/recipes/gb200-fp4/8k1k/max-tpt.yaml
@@ -163,6 +163,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb200-fp4/8k1k/mid-curve.yaml
+++ b/recipes/gb200-fp4/8k1k/mid-curve.yaml
@@ -163,6 +163,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb200-fp8/1k1k/low-latency-mtp.yaml
+++ b/recipes/gb200-fp8/1k1k/low-latency-mtp.yaml
@@ -85,6 +85,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -114,6 +115,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/recipes/gb200-fp8/1k1k/low-latency.yaml
+++ b/recipes/gb200-fp8/1k1k/low-latency.yaml
@@ -84,6 +84,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-bootstrap-port: 30001
       disaggregation-transfer-backend: nixl
 
@@ -109,6 +110,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp8-gemm-backend: "flashinfer_trtllm"
       disaggregation-bootstrap-port: 30001
       disaggregation-transfer-backend: nixl

--- a/recipes/gb200-fp8/1k1k/max-tpt-2p1d-mtp.yaml
+++ b/recipes/gb200-fp8/1k1k/max-tpt-2p1d-mtp.yaml
@@ -76,6 +76,7 @@ backend:
       dp-size: 8
       ep-size: 8
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -135,6 +136,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k1k/max-tpt.yaml
+++ b/recipes/gb200-fp8/1k1k/max-tpt.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -125,6 +126,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k1k/mid-curve-3p1d-mtp.yaml
+++ b/recipes/gb200-fp8/1k1k/mid-curve-3p1d-mtp.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -131,6 +132,7 @@ backend:
       dp-size: 48
       ep-size: 48
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k1k/mid-curve.yaml
+++ b/recipes/gb200-fp8/1k1k/mid-curve.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -124,6 +125,7 @@ backend:
       dp-size: 48
       ep-size: 48
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k1k/ultra-tpt.yaml
+++ b/recipes/gb200-fp8/1k1k/ultra-tpt.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -126,6 +127,7 @@ backend:
       dp-size: 8
       ep-size: 8
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k8k/low-latency-mtp.yaml
+++ b/recipes/gb200-fp8/1k8k/low-latency-mtp.yaml
@@ -83,6 +83,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -113,6 +114,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/recipes/gb200-fp8/1k8k/low_latency.yaml
+++ b/recipes/gb200-fp8/1k8k/low_latency.yaml
@@ -85,6 +85,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: nixl
 
     decode:
@@ -111,6 +112,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp8-gemm-backend: "flashinfer_trtllm"
 
       disaggregation-transfer-backend: nixl

--- a/recipes/gb200-fp8/1k8k/max-tpt-mtp.yaml
+++ b/recipes/gb200-fp8/1k8k/max-tpt-mtp.yaml
@@ -70,6 +70,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -128,6 +129,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k8k/max_tpt.yaml
+++ b/recipes/gb200-fp8/1k8k/max_tpt.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -125,6 +126,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k8k/mid-curve-mtp.yaml
+++ b/recipes/gb200-fp8/1k8k/mid-curve-mtp.yaml
@@ -70,6 +70,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -122,6 +123,7 @@ backend:
       dp-size: 48
       ep-size: 48
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/1k8k/mid_curve.yaml
+++ b/recipes/gb200-fp8/1k8k/mid_curve.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -124,6 +125,7 @@ backend:
       dp-size: 48
       ep-size: 48
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/8k1k/low-latency-mtp.yaml
+++ b/recipes/gb200-fp8/8k1k/low-latency-mtp.yaml
@@ -82,6 +82,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -110,6 +111,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: "nixl"
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/recipes/gb200-fp8/8k1k/low-latency.yaml
+++ b/recipes/gb200-fp8/8k1k/low-latency.yaml
@@ -80,6 +80,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp8-gemm-backend: "flashinfer_trtllm"
       disaggregation-bootstrap-port: 30001
       disaggregation-transfer-backend: nixl
@@ -105,6 +106,7 @@ backend:
       tensor-parallel-size: 8
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp8-gemm-backend: "flashinfer_trtllm"
       disaggregation-bootstrap-port: 30001
       disaggregation-transfer-backend: nixl

--- a/recipes/gb200-fp8/8k1k/max_tpt.yaml
+++ b/recipes/gb200-fp8/8k1k/max_tpt.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -124,6 +125,7 @@ backend:
       dp-size: 24
       ep-size: 24
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/8k1k/mid-curve-5p1d-mtp.yaml
+++ b/recipes/gb200-fp8/8k1k/mid-curve-5p1d-mtp.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -131,6 +132,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb200-fp8/8k1k/mid-curve.yaml
+++ b/recipes/gb200-fp8/8k1k/mid-curve.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -124,6 +125,7 @@ backend:
       dp-size: 32
       ep-size: 32
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp4/128k8k/1-top-of-curve.yaml
+++ b/recipes/gb300-fp4/128k8k/1-top-of-curve.yaml
@@ -67,6 +67,7 @@ backend:
       disaggregation-mode: decode
       disaggregation-transfer-backend: nixl
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-symm-mem: true
       expert-parallel-size: 4
       kv-cache-dtype: fp8_e4m3

--- a/recipes/gb300-fp4/128k8k/2-mid-curve-pt1.yaml
+++ b/recipes/gb300-fp4/128k8k/2-mid-curve-pt1.yaml
@@ -67,6 +67,7 @@ backend:
       disaggregation-mode: decode
       disaggregation-transfer-backend: nixl
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-symm-mem: true
       expert-parallel-size: 4
       kv-cache-dtype: fp8_e4m3

--- a/recipes/gb300-fp4/128k8k/3-mid-curve-pt2.yaml
+++ b/recipes/gb300-fp4/128k8k/3-mid-curve-pt2.yaml
@@ -68,6 +68,7 @@ backend:
       disaggregation-mode: decode
       disaggregation-transfer-backend: nixl
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-symm-mem: true
       expert-parallel-size: 4
       kv-cache-dtype: fp8_e4m3

--- a/recipes/gb300-fp4/128k8k/4-mid-curve-pt3.yaml
+++ b/recipes/gb300-fp4/128k8k/4-mid-curve-pt3.yaml
@@ -68,6 +68,7 @@ backend:
       disaggregation-mode: decode
       disaggregation-transfer-backend: nixl
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       enable-symm-mem: true
       expert-parallel-size: 8
       kv-cache-dtype: fp8_e4m3

--- a/recipes/gb300-fp4/128k8k/5-low-latency.yaml
+++ b/recipes/gb300-fp4/128k8k/5-low-latency.yaml
@@ -95,6 +95,7 @@ backend:
       disaggregation-transfer-backend: nixl
       enable-symm-mem: true
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       kv-cache-dtype: fp8_e4m3
       load-balance-method: round_robin
       max-total-tokens: 544000

--- a/recipes/gb300-fp4/1k1k/low_latency.yaml
+++ b/recipes/gb300-fp4/1k1k/low_latency.yaml
@@ -81,6 +81,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 
@@ -105,6 +106,7 @@ backend:
       enable-symm-mem: true
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp4/1k1k/max_tpt.yaml
+++ b/recipes/gb300-fp4/1k1k/max_tpt.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       disaggregation-transfer-backend: nixl
       fp4-gemm-backend: "flashinfer_cutlass"
 
@@ -167,6 +168,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp4/1k1k/mid_curve.yaml
+++ b/recipes/gb300-fp4/1k1k/mid_curve.yaml
@@ -107,6 +107,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism
@@ -166,6 +167,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp4/1k8k/low-latency.yaml
+++ b/recipes/gb300-fp4/1k8k/low-latency.yaml
@@ -79,6 +79,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 
@@ -102,6 +103,7 @@ backend:
       scheduler-recv-interval: 10
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp4/1k8k/max-tpt.yaml
+++ b/recipes/gb300-fp4/1k8k/max-tpt.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism
@@ -233,6 +234,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism

--- a/recipes/gb300-fp4/1k8k/mid-curve.yaml
+++ b/recipes/gb300-fp4/1k8k/mid-curve.yaml
@@ -106,6 +106,7 @@ backend:
       # Performance optimizations
       disable-cuda-graph: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
 
       # Parallelism
@@ -232,6 +233,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"  # Only for 0.5.8
 
       # Parallelism

--- a/recipes/gb300-fp4/8k1k/low_latency.yaml
+++ b/recipes/gb300-fp4/8k1k/low_latency.yaml
@@ -81,6 +81,7 @@ backend:
       data-parallel-size: 1
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       enable-dp-attention: false
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl
@@ -107,6 +108,7 @@ backend:
       enable-symm-mem: true
       tensor-parallel-size: 4
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       enable-dp-attention: false
       fp4-gemm-backend: "flashinfer_trtllm"
       disaggregation-transfer-backend: nixl

--- a/recipes/gb300-fp4/8k1k/max_tpt.yaml
+++ b/recipes/gb300-fp4/8k1k/max_tpt.yaml
@@ -163,6 +163,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp4/8k1k/mid_curve.yaml
+++ b/recipes/gb300-fp4/8k1k/mid_curve.yaml
@@ -163,6 +163,7 @@ backend:
       enable-dp-lm-head: true
       prefill-round-robin-balance: true
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
       fp4-gemm-backend: "flashinfer_cutlass"
       disaggregation-transfer-backend: nixl
 

--- a/recipes/gb300-fp8/1k1k/mtp/low-latency.yaml
+++ b/recipes/gb300-fp8/1k1k/mtp/low-latency.yaml
@@ -90,6 +90,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1
@@ -120,6 +121,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1

--- a/recipes/gb300-fp8/1k1k/mtp/max.yaml
+++ b/recipes/gb300-fp8/1k1k/mtp/max.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -132,6 +133,7 @@ backend:
       dp-size: 8 
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k1k/mtp/mid.yaml
+++ b/recipes/gb300-fp8/1k1k/mtp/mid.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -131,6 +132,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k1k/stp/low-latency.yaml
+++ b/recipes/gb300-fp8/1k1k/stp/low-latency.yaml
@@ -86,6 +86,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
     decode:
       served-model-name: "deepseek-ai/DeepSeek-R1"
@@ -112,6 +113,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
 benchmark:
   type: "sa-bench"

--- a/recipes/gb300-fp8/1k1k/stp/max.yaml
+++ b/recipes/gb300-fp8/1k1k/stp/max.yaml
@@ -69,6 +69,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -122,6 +123,7 @@ backend:
       dp-size: 8 
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k1k/stp/mid.yaml
+++ b/recipes/gb300-fp8/1k1k/stp/mid.yaml
@@ -68,6 +68,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -121,6 +122,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k8k/mtp/low-latency.yaml
+++ b/recipes/gb300-fp8/1k8k/mtp/low-latency.yaml
@@ -90,6 +90,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1
@@ -120,6 +121,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1

--- a/recipes/gb300-fp8/1k8k/mtp/max.yaml
+++ b/recipes/gb300-fp8/1k8k/mtp/max.yaml
@@ -76,6 +76,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -135,6 +136,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k8k/mtp/mid.yaml
+++ b/recipes/gb300-fp8/1k8k/mtp/mid.yaml
@@ -76,6 +76,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -135,6 +136,7 @@ backend:
       dp-size: 48 
       ep-size: 48 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k8k/stp/low-latency.yaml
+++ b/recipes/gb300-fp8/1k8k/stp/low-latency.yaml
@@ -86,6 +86,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
     decode:
       served-model-name: "deepseek-ai/DeepSeek-R1"
@@ -112,6 +113,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
 benchmark:
   type: "sa-bench"

--- a/recipes/gb300-fp8/1k8k/stp/max.yaml
+++ b/recipes/gb300-fp8/1k8k/stp/max.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -125,6 +126,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/1k8k/stp/mid.yaml
+++ b/recipes/gb300-fp8/1k8k/stp/mid.yaml
@@ -72,6 +72,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -125,6 +126,7 @@ backend:
       dp-size: 48 
       ep-size: 48 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/8k1k/mtp/low-latency.yaml
+++ b/recipes/gb300-fp8/8k1k/mtp/low-latency.yaml
@@ -90,6 +90,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1
@@ -120,6 +121,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
       speculative-eagle-topk: 1

--- a/recipes/gb300-fp8/8k1k/mtp/max.yaml
+++ b/recipes/gb300-fp8/8k1k/mtp/max.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -132,6 +133,7 @@ backend:
       dp-size: 24 
       ep-size: 24 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/8k1k/mtp/mid.yaml
+++ b/recipes/gb300-fp8/8k1k/mtp/mid.yaml
@@ -73,6 +73,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -132,6 +133,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/8k1k/stp/low-latency.yaml
+++ b/recipes/gb300-fp8/8k1k/stp/low-latency.yaml
@@ -86,6 +86,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
     decode:
       served-model-name: "deepseek-ai/DeepSeek-R1"
@@ -112,6 +113,7 @@ backend:
       tensor-parallel-size: 4
       data-parallel-size: 1
       expert-parallel-size: 1
+      numa-node: [0, 0, 1, 1]
 
 benchmark:
   type: "sa-bench"

--- a/recipes/gb300-fp8/8k1k/stp/max.yaml
+++ b/recipes/gb300-fp8/8k1k/stp/max.yaml
@@ -69,6 +69,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -122,6 +123,7 @@ backend:
       dp-size: 24 
       ep-size: 24 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"

--- a/recipes/gb300-fp8/8k1k/stp/mid.yaml
+++ b/recipes/gb300-fp8/8k1k/stp/mid.yaml
@@ -69,6 +69,7 @@ backend:
       dp-size: 8
       ep-size: 8 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"
@@ -122,6 +123,7 @@ backend:
       dp-size: 32 
       ep-size: 32 
       enable-dp-attention: true
+      numa-node: [0, 0, 1, 1]
 
       # KV cache and attention
       attention-backend: "trtllm_mla"


### PR DESCRIPTION
Grace-blackwell systems are composed of two numa nodes. Node 0 contains GPUs 0,1 and cpu cores 0-71. Node 1 contains GPUs 2,3 and cpu cores 72-144. Each numa node also has a unified memory between its cpus and gpus. This PR ensures that worker processes are bound to the correct numa node for their gpu that they are assigned to.