### PR TITLE
Add Qwen3.5-397B-A17B B200 BF16 aggregated recipes for 1k1k

### DIFF
--- a/recipes/b200-bf16/1k1k/low-latency.yaml
+++ b/recipes/b200-bf16/1k1k/low-latency.yaml
@@ -33,13 +33,12 @@ backend:
       mem-fraction-static: 0.82
       chunked-prefill-size: 32768
       max-prefill-tokens: 32768
-      cuda-graph-max-bs: 128
-      max-running-requests: 128
+      cuda-graph-max-bs: 16
+      max-running-requests: 16
 
-      stream-interval: 30
+      stream-interval: 10
       scheduler-recv-interval: 10
       enable-flashinfer-allreduce-fusion: true
-      enable-symm-mem: true
 
 benchmark:
   type: "sa-bench"

--- a/recipes/b200-bf16/1k1k/max-tpt.yaml
+++ b/recipes/b200-bf16/1k1k/max-tpt.yaml
@@ -39,7 +39,6 @@ backend:
       stream-interval: 30
       scheduler-recv-interval: 30
       enable-flashinfer-allreduce-fusion: true
-      enable-symm-mem: true
 
 benchmark:
   type: "sa-bench"


### PR DESCRIPTION
Two recipes for the Qwen3.5-397B-A17B model on B200 GPUs (BF16, TP8):
- max-tpt.yaml: high concurrency (16/32/64) with scheduler-recv-interval=30
- low-latency.yaml: low concurrency (4/8) with scheduler-recv-interval=10

Incorporates SGLang optimizations (chunked-prefill, flashinfer allreduce fusion, CUDA graph tuning) validated to match/exceed colleague benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two new deployment configuration templates for the Qwen 3.5 (397B) model: one optimized for low-latency inference and another for maximum-throughput.
  * Both templates target B200 GPU deployments with BF16 precision and include aggregated runtime options and benchmark parameters for 1k1k performance testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->