### PR TITLE
Add gpt-oss-120b FP4 disaggregated benchmark recipes for GB200

### DIFF
--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_dep2_batch1536_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_dep2_batch1536_eplb0_mtp0.yaml
@@ -1,0 +1,107 @@
+name: "ctx1_gen1_dep2_batch1536_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+  gpus_per_decode: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TRTLLM_MOE_ALLTOALL_BACKEND: "mnnvlthroughput"
+    TRTLLM_FORCE_ALLTOALL_METHOD: "MNNVL"
+    TRTLLM_MOE_A2A_WORKSPACE_MB: "2048"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
+      enable_attention_dp: true
+      pipeline_parallel_size: 1
+      max_batch_size: 1536
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1536
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "256x512x1024x2048x2560"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_dep4_batch512_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_dep4_batch512_eplb0_mtp0.yaml
@@ -1,0 +1,106 @@
+name: "ctx1_gen1_dep4_batch512_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TRTLLM_MOE_ALLTOALL_BACKEND: "mnnvlthroughput"
+    TRTLLM_FORCE_ALLTOALL_METHOD: "MNNVL"
+    TRTLLM_MOE_A2A_WORKSPACE_MB: "2048"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      enable_attention_dp: true
+      pipeline_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 512
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "256x1024x1536"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_tp4_batch256_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen1_tp4_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,103 @@
+name: "ctx1_gen1_tp4_batch256_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 256
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 256
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "1x2x4x16x32x64x128"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen2_dep2_batch1536_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen2_dep2_batch1536_eplb0_mtp0.yaml
@@ -1,0 +1,107 @@
+name: "ctx1_gen2_dep2_batch1536_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 2
+  decode_nodes: 2
+  gpus_per_decode: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TRTLLM_MOE_ALLTOALL_BACKEND: "mnnvlthroughput"
+    TRTLLM_FORCE_ALLTOALL_METHOD: "MNNVL"
+    TRTLLM_MOE_A2A_WORKSPACE_MB: "2048"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
+      enable_attention_dp: true
+      pipeline_parallel_size: 1
+      max_batch_size: 1536
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1536
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "512x1024x2048x2560"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen3_dep4_batch1024_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen3_dep4_batch1024_eplb0_mtp0.yaml
@@ -1,0 +1,106 @@
+name: "ctx1_gen3_dep4_batch1024_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 3
+  decode_nodes: 3
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TRTLLM_MOE_ALLTOALL_BACKEND: "mnnvlthroughput"
+    TRTLLM_FORCE_ALLTOALL_METHOD: "MNNVL"
+    TRTLLM_MOE_A2A_WORKSPACE_MB: "2048"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      enable_attention_dp: true
+      pipeline_parallel_size: 1
+      max_batch_size: 1024
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1024
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "3072"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen4_tp2_batch32_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/1k1k/stp/ctx1_gen4_tp2_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,104 @@
+name: "ctx1_gen4_tp2_batch32_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 4
+  decode_nodes: 4
+  gpus_per_decode: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 1227
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 2251
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 1024
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "16"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx1_gen1_tp4_batch128_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx1_gen1_tp4_batch128_eplb0_mtp0.yaml
@@ -1,0 +1,103 @@
+name: "ctx1_gen1_tp4_batch128_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 8395
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 128
+      max_num_tokens: 20000
+      max_seq_len: 9419
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 128
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "2x4x8x16x32x64"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx1_gen1_tp8_batch4_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx1_gen1_tp8_batch4_eplb0_mtp0.yaml
@@ -1,0 +1,103 @@
+name: "ctx1_gen1_tp8_batch4_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 8395
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 4
+      max_num_tokens: 20000
+      max_seq_len: 9419
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 4
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_dep2_batch512_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_dep2_batch512_eplb0_mtp0.yaml
@@ -1,0 +1,107 @@
+name: "ctx2_gen1_dep2_batch512_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+  gpus_per_decode: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TRTLLM_MOE_ALLTOALL_BACKEND: "mnnvlthroughput"
+    TRTLLM_FORCE_ALLTOALL_METHOD: "MNNVL"
+    TRTLLM_MOE_A2A_WORKSPACE_MB: "2048"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 8395
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
+      enable_attention_dp: true
+      pipeline_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 9419
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 512
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "128x512"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_tp2_batch512_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_tp2_batch512_eplb0_mtp0.yaml
@@ -1,0 +1,104 @@
+name: "ctx2_gen1_tp2_batch512_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+  gpus_per_decode: 2
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 8395
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 9419
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 512
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "256x384"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_tp4_batch1024_eplb0_mtp0.yaml
+++ b/recipes/trtllm/gptoss-fp4/8k1k/stp/ctx2_gen1_tp4_batch1024_eplb0_mtp0.yaml
@@ -1,0 +1,103 @@
+name: "ctx2_gen1_tp4_batch1024_eplb0_mtp0"
+
+model:
+  path: "gptoss"
+  container: "dynamo-trtllm"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 1
+
+  decode_workers: 1
+  decode_nodes: 1
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  decode_environment:
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_GRAPH_REGISTER: "0"
+    TRTLLM_ENABLE_PDL: "1"
+    OVERRIDE_QUANT_ALGO: "W4A8_MXFP4_MXFP8"
+    OMPI_MCA_coll_ucc_enable: "0"
+
+  trtllm_config:
+    prefill:
+      max_batch_size: 32
+      max_num_tokens: 20000
+      max_seq_len: 8395
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+        dtype: fp8
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      num_postprocess_workers: 4
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 1
+      enable_attention_dp: false
+      pipeline_parallel_size: 1
+      max_batch_size: 1024
+      max_num_tokens: 20000
+      max_seq_len: 9419
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1024
+      print_iter_log: true
+      disable_overlap_scheduler: false
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      moe_config:
+        backend: TRTLLM
+      cache_transceiver_config:
+        max_tokens_in_buffer: 8448
+        backend: UCX
+      stream_interval: 20
+      num_postprocess_workers: 4
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "128x512"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+dynamo:
+  install: false
+
+infra:
+  etcd_nats_dedicated_node: true

--- a/src/srtctl/backends/base.py
+++ b/src/srtctl/backends/base.py
@@ -82,6 +82,9 @@ class BackendProtocol(Protocol):
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        *,
+        prefill_nodes: int = 0,
+        decode_nodes: int = 0,
     ) -> list["Endpoint"]:
         """Allocate logical endpoints based on resource requirements."""
         ...

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -179,6 +179,9 @@ class SGLangProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        *,
+        prefill_nodes: int = 0,
+        decode_nodes: int = 0,
     ) -> list["Endpoint"]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -192,6 +195,8 @@ class SGLangProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            prefill_nodes=prefill_nodes,
+            decode_nodes=decode_nodes,
         )
 
     def endpoints_to_processes(

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -125,6 +125,9 @@ class TRTLLMProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        *,
+        prefill_nodes: int = 0,
+        decode_nodes: int = 0,
     ) -> list["Endpoint"]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -138,6 +141,8 @@ class TRTLLMProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            prefill_nodes=prefill_nodes,
+            decode_nodes=decode_nodes,
         )
 
     def endpoints_to_processes(
@@ -189,12 +194,16 @@ class TRTLLMProtocol:
         if mode != "agg":
             cmd.extend(["--disaggregation-mode", mode])
 
+        # Pass key params as CLI args (YAML-only may not be respected)
+        for key in ("max_num_tokens", "max_batch_size", "max_seq_len"):
+            if key in config:
+                cli_key = key.replace("_", "-")
+                cmd.extend([f"--{cli_key}", str(config[key])])
+
         cmd.extend(
             [
                 "--extra-engine-args",
                 str(container_config_path),
-                "--request-plane",
-                "nats",
             ]
         )
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -156,6 +156,9 @@ class VLLMProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        *,
+        prefill_nodes: int = 0,
+        decode_nodes: int = 0,
     ) -> list[Endpoint]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -169,6 +172,8 @@ class VLLMProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            prefill_nodes=prefill_nodes,
+            decode_nodes=decode_nodes,
         )
 
     def _is_dp_mode(self, mode: WorkerMode) -> bool:

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -75,6 +75,8 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
             gpus_per_agg=r.gpus_per_agg,
             gpus_per_node=r.gpus_per_node,
             available_nodes=self.runtime.nodes.worker,
+            prefill_nodes=r.prefill_nodes or 0,
+            decode_nodes=r.decode_nodes or 0,
         )
 
     @functools.cached_property

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -188,10 +188,17 @@ def allocate_endpoints(
     gpus_per_agg: int,
     gpus_per_node: int,
     available_nodes: Sequence[str],
+    *,
+    prefill_nodes: int = 0,
+    decode_nodes: int = 0,
 ) -> list[Endpoint]:
     """Allocate endpoints to nodes based on GPU requirements.
 
     This is the core allocation logic that replaces bash array math.
+
+    When prefill_nodes or decode_nodes are provided and exceed the minimum
+    needed for packing, each worker is given a dedicated node to avoid
+    co-location conflicts (e.g., TRT-LLM ZMQ port collisions).
 
     Args:
         num_prefill: Number of prefill workers
@@ -202,6 +209,8 @@ def allocate_endpoints(
         gpus_per_agg: GPUs per agg worker
         gpus_per_node: GPUs available per node
         available_nodes: List of available node hostnames
+        prefill_nodes: Total nodes reserved for prefill (0 = auto-pack)
+        decode_nodes: Total nodes reserved for decode (0 = auto-pack)
 
     Returns:
         List of Endpoint objects with node assignments
@@ -226,76 +235,23 @@ def allocate_endpoints(
     node_idx = 0
     gpu_offset = 0  # Track GPU offset within current node
 
-    def allocate_worker(mode: WorkerMode, index: int, gpus_needed: int) -> Endpoint:
-        """Allocate a single worker endpoint."""
-        nonlocal node_idx, gpu_offset
+    # Determine if workers should get dedicated nodes (no packing).
+    # When the user specifies more nodes than packing would require,
+    # each worker should get its own node to avoid port conflicts.
+    prefill_dedicated = (
+        num_prefill > 0
+        and gpus_per_prefill < gpus_per_node
+        and prefill_nodes >= num_prefill
+    )
+    decode_dedicated = (
+        num_decode > 0
+        and gpus_per_decode < gpus_per_node
+        and decode_nodes >= num_decode
+    )
 
-        if gpus_needed <= 0:
-            raise ValueError(f"gpus_needed must be positive, got {gpus_needed}")
-
-        # Calculate how many nodes this worker spans
-        nodes_per_worker = (gpus_needed + gpus_per_node - 1) // gpus_per_node
-
-        # For multi-node workers, start fresh on node boundary
-        if (nodes_per_worker > 1 or gpus_needed == gpus_per_node) and gpu_offset > 0:
-            node_idx += 1
-            gpu_offset = 0
-
-        # Collect nodes for this worker
-        worker_nodes = []
-        for _ in range(nodes_per_worker):
-            if node_idx >= len(available_nodes):
-                raise ValueError(f"Not enough nodes: need node {node_idx}, but only {len(available_nodes)} available")
-            worker_nodes.append(available_nodes[node_idx])
-            node_idx += 1
-
-        # Determine GPU indices (full node for multi-node, or specific range for single)
-        if nodes_per_worker > 1:
-            gpu_indices = frozenset(range(gpus_per_node))
-            gpu_offset = 0
-        else:
-            # Single node: might be partial or full
-            if gpu_offset + gpus_needed > gpus_per_node:
-                # Doesn't fit, move to next node
-                node_idx += 1
-                if node_idx > len(available_nodes):
-                    raise ValueError("Not enough nodes for GPU allocation")
-                worker_nodes = [available_nodes[node_idx - 1]]
-                gpu_offset = 0
-
-            gpu_indices = frozenset(range(gpu_offset, gpu_offset + gpus_needed))
-            gpu_offset += gpus_needed
-
-            # If we filled the node, move to next
-            if gpu_offset >= gpus_per_node:
-                node_idx += 1
-                gpu_offset = 0
-            else:
-                # Still on same node, rewind node_idx for next partial worker
-                node_idx -= len(worker_nodes) - 1 if len(worker_nodes) > 1 else 0
-
-        # Fix: for single-node workers staying on same node
-        if nodes_per_worker == 1 and gpu_offset > 0 and gpu_offset < gpus_per_node:
-            # We're still on the same node, don't increment
-            pass
-        elif nodes_per_worker == 1 and gpu_offset == 0:
-            # We moved to a new node after filling previous
-            pass
-
-        return Endpoint(
-            mode=mode,
-            index=index,
-            nodes=tuple(worker_nodes),
-            gpu_indices=gpu_indices,
-            gpus_per_node=gpus_per_node,
-        )
-
-    # Reset for cleaner allocation
-    node_idx = 0
-    gpu_offset = 0
-
-    # Simpler allocation: each worker gets nodes sequentially
-    def allocate_workers_simple(mode: WorkerMode, count: int, gpus_per_worker: int) -> list[Endpoint]:
+    def allocate_workers_simple(
+        mode: WorkerMode, count: int, gpus_per_worker: int, dedicated_node: bool = False,
+    ) -> list[Endpoint]:
         nonlocal node_idx, gpu_offset
         result = []
 
@@ -317,7 +273,13 @@ def allocate_endpoints(
                     )
                 )
             else:
-                # Partial node worker - pack multiple on same node
+                # Partial node worker
+                if dedicated_node:
+                    # Force each worker onto a fresh node
+                    if gpu_offset > 0:
+                        node_idx += 1
+                        gpu_offset = 0
+
                 if gpu_offset + gpus_per_worker > gpus_per_node:
                     node_idx += 1
                     gpu_offset = 0
@@ -326,7 +288,11 @@ def allocate_endpoints(
                 gpu_indices = frozenset(range(gpu_offset, gpu_offset + gpus_per_worker))
                 gpu_offset += gpus_per_worker
 
-                if gpu_offset >= gpus_per_node:
+                if dedicated_node:
+                    # Advance past remaining GPUs on this node
+                    node_idx += 1
+                    gpu_offset = 0
+                elif gpu_offset >= gpus_per_node:
                     node_idx += 1
                     gpu_offset = 0
 
@@ -344,7 +310,7 @@ def allocate_endpoints(
 
     # Allocate in order: prefill, decode, agg
     if num_prefill > 0:
-        endpoints.extend(allocate_workers_simple("prefill", num_prefill, gpus_per_prefill))
+        endpoints.extend(allocate_workers_simple("prefill", num_prefill, gpus_per_prefill, prefill_dedicated))
 
     # When there's a partial allocation on the current node (gpu_offset > 0) and
     # there are more nodes available, advance to ensure prefill and decode don't
@@ -355,7 +321,7 @@ def allocate_endpoints(
         if gpu_offset > 0 and (node_idx + 1) < len(available_nodes):
             node_idx += 1
             gpu_offset = 0
-        endpoints.extend(allocate_workers_simple("decode", num_decode, gpus_per_decode))
+        endpoints.extend(allocate_workers_simple("decode", num_decode, gpus_per_decode, decode_dedicated))
 
     if num_agg > 0:
         endpoints.extend(allocate_workers_simple("agg", num_agg, gpus_per_agg))


### PR DESCRIPTION
Add 11 srt-slurm recipes for gpt-oss-120b FP4 on GB200 NVL72 (ptyche), translated from SemiAnalysis InferenceX configurations. Includes both TP and DEP (disaggregated expert parallel) configs across 1K/1K and 8K/1K input/output sequence lengths.

Recipes:
- 1k1k: 6 configs (2 TP, 4 DEP) covering 3-13 GPU topologies
- 8k1k: 5 configs (4 TP, 1 DEP) covering 4-9 GPU topologies

DEP recipes include MNNVL-optimized MoE all-to-all env vars (TRTLLM_MOE_ALLTOALL_BACKEND, TRTLLM_FORCE_ALLTOALL_METHOD, TRTLLM_MOE_A2A_WORKSPACE_MB) on decode workers, matching the original SA benchmark scripts.

Also includes backwards-compatible topology changes:
- Support dedicated_node allocation via prefill_nodes/decode_nodes kwargs (default 0 = existing packing behavior) to prevent ZMQ port collisions when partial-GPU workers land on the same node
- Pass --max-num-tokens/--max-batch-size/--max-seq-len as CLI args to trtllm worker (YAML-only may not be respected per upstream)

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added prefill and decode stage-specific node allocation parameters to enable dedicated resource assignment across multiple backend implementations.
  * Introduced eight new deployment configuration templates for GPT-OSS FP4 models, supporting diverse batch sizes, tensor parallelism settings, and context lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->