### PR TITLE
recipes: consolidate B200 recipes and fix config correctness

### DIFF
--- a/recipes/b200-fp4/1k1k-mtp.yaml
+++ b/recipes/b200-fp4/1k1k-mtp.yaml
@@ -1,9 +1,17 @@
 # B200-FP4 1k1k MTP — all scale variants in one file
 #
+# Two decode modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings +
+#                       SGLANG_MOE_NVFP4_DISPATCH / SGLANG_FLASHINFER_FP4_GEMM_BACKEND
+#
+# Note: max-tpt 1d has max-running-requests=1024 and mem-fraction=0.75 for decode;
+#       max-tpt 2d keeps 512/0.85 (list values handle per-variant differences).
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp4/1k1k-mtp.yaml                       # all 4 variants
-#   srtctl apply  -f recipes/b200-fp4/1k1k-mtp.yaml:zip_override_scale[0] # 1p5d low-lat
-#   srtctl dry-run -f recipes/b200-fp4/1k1k-mtp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp4/1k1k-mtp.yaml                          # all 4 variants
+#   srtctl apply  -f recipes/b200-fp4/1k1k-mtp.yaml:zip_override_lowlat[0]  # 1p5d low-lat only
+#   srtctl dry-run -f recipes/b200-fp4/1k1k-mtp.yaml                        # preview
 
 base:
   name: "b200-fp4-mtp-1k1k"
@@ -124,15 +132,42 @@ base:
     req_rate: "inf"
 
 
-# Sweep: low-latency (1p5d, 1p6d) and max-throughput (1p1d, 1p2d)
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p5d and 1p6d
+zip_override_lowlat:
   name:
     - "b200-fp4-low-latency-dep4-1p-tep8-5d"
     - "b200-fp4-low-latency-dep4-1p-tep8-6d"
+  resources:
+    decode_nodes: [5, 6]
+    decode_workers: [5, 6]
+  benchmark:
+    concurrencies: ["16x512", "32x64x256x512"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p1d and 1p2d
+# 1d: max-running-requests=1024, mem-fraction=0.75
+# 2d: max-running-requests=512 (base), mem-fraction=0.85 (base)
+zip_override_maxtpt:
+  name:
     - "b200-fp4-max-tpt-dep4-1p-dep8-1d"
     - "b200-fp4-max-tpt-dep4-1p-dep8-2d"
   resources:
-    decode_nodes: [5, 6, 1, 2]
-    decode_workers: [5, 6, 1, 2]
+    decode_nodes: [1, 2]
+    decode_workers: [1, 2]
+  backend:
+    decode_environment:
+      SGLANG_MOE_NVFP4_DISPATCH: "1"
+      SGLANG_FLASHINFER_FP4_GEMM_BACKEND: "cutlass"
+    sglang_config:
+      prefill:
+        max-running-requests: [1024, 512]
+      decode:
+        mem-fraction-static: [0.75, 0.85]
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: [1024, 512]
+        cuda-graph-max-bs: [1024, 512]
   benchmark:
-    concurrencies: ["16x512", "32x64x256x512", "512x1024", "512"]
+    concurrencies: ["512x1024", "512"]

--- a/recipes/b200-fp4/1k1k-stp.yaml
+++ b/recipes/b200-fp4/1k1k-stp.yaml
@@ -1,9 +1,16 @@
 # B200-FP4 1k1k STP — all scale variants in one file
 #
+# Two decode modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings +
+#                       SGLANG_MOE_NVFP4_DISPATCH / SGLANG_FLASHINFER_FP4_GEMM_BACKEND
+#
+# Note: max-tpt 1d has max-running-requests=1024; max-tpt 2d keeps 512.
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp4/1k1k-stp.yaml                       # all 4 variants
-#   srtctl apply  -f recipes/b200-fp4/1k1k-stp.yaml:zip_override_scale[0] # 1p5d low-lat
-#   srtctl dry-run -f recipes/b200-fp4/1k1k-stp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp4/1k1k-stp.yaml                          # all 4 variants
+#   srtctl apply  -f recipes/b200-fp4/1k1k-stp.yaml:zip_override_lowlat[0]  # 1p5d low-lat only
+#   srtctl dry-run -f recipes/b200-fp4/1k1k-stp.yaml                        # preview
 
 base:
   name: "b200-fp4-stp-1k1k"
@@ -116,15 +123,40 @@ base:
     req_rate: "inf"
 
 
-# Sweep: low-latency (1p5d, 1p6d) and max-throughput (1p1d, 1p2d)
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p5d and 1p6d
+zip_override_lowlat:
   name:
     - "b200-fp4-low-latency-dep4-1p-tep8-5d"
     - "b200-fp4-low-latency-dep4-1p-tep8-6d"
+  resources:
+    decode_nodes: [5, 6]
+    decode_workers: [5, 6]
+  benchmark:
+    concurrencies: ["16x128", "32x64x256"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p1d and 1p2d
+# Note: 1d has max-running-requests=1024; 2d keeps 512 (scale determines optimal batch)
+zip_override_maxtpt:
+  name:
     - "b200-fp4-max-tpt-dep4-1p-dep8-1d"
     - "b200-fp4-max-tpt-dep4-1p-dep8-2d"
   resources:
-    decode_nodes: [5, 6, 1, 2]
-    decode_workers: [5, 6, 1, 2]
+    decode_nodes: [1, 2]
+    decode_workers: [1, 2]
+  backend:
+    decode_environment:
+      SGLANG_MOE_NVFP4_DISPATCH: "1"
+      SGLANG_FLASHINFER_FP4_GEMM_BACKEND: "cutlass"
+    sglang_config:
+      prefill:
+        max-running-requests: [1024, 512]
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: [1024, 512]
+        cuda-graph-max-bs: [1024, 512]
   benchmark:
-    concurrencies: ["16x128", "32x64x256", "512", "512"]
+    concurrencies: ["512", "512"]

--- a/recipes/b200-fp4/8k1k-mtp.yaml
+++ b/recipes/b200-fp4/8k1k-mtp.yaml
@@ -1,14 +1,17 @@
 # B200-FP4 8k1k MTP — all variants in one file
 #
-# Two prefill modes:
-#   dep4 (default): DP4 prefill — tensor-parallel-size=4, data-parallel-size=4
-#   tp4  (override_tp4): TP4 prefill — tensor-parallel-size=4, data-parallel-size=1
+# Three modes:
+#   dep4 low-lat (default): DP4 prefill + tep8 decode (DP=1)
+#   tp4  (override_tp4):    TP4 prefill (DP=1, EP=1) — for low-latency single-node
+#   dep8 max-tpt:
+#     override_maxtpt_4p1d: 4p1d, no frontends, SGLANG_FLASHINFER_FP4_GEMM_BACKEND, mem=0.75
+#     override_maxtpt_7p2d: 7p2d, with frontends, flashinfer_cutlass, max-running-requests=2048
 #
 # Usage:
-#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml                       # all 5 dep4 variants
-#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml:override_tp4          # tp4 variant
-#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml:zip_override_scale[0] # 1p1d dep4 only
-#   srtctl dry-run -f recipes/b200-fp4/8k1k-mtp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml                         # all 6 variants
+#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml:override_tp4            # tp4 variant
+#   srtctl apply  -f recipes/b200-fp4/8k1k-mtp.yaml:zip_override_lowlat[0]  # 1p1d dep4 only
+#   srtctl dry-run -f recipes/b200-fp4/8k1k-mtp.yaml                        # preview
 
 base:
   name: "b200-fp4-mtp-8k1k"
@@ -18,6 +21,9 @@ base:
     container: "dynamo-sglang"
     precision: "fp4"
 
+  frontend:
+    num_additional_frontends: 4
+
   resources:
     gpu_type: "b200"
     prefill_nodes: 1
@@ -25,7 +31,6 @@ base:
     gpus_per_prefill: 4
     decode_nodes: 1
     decode_workers: 1
-    num_additional_frontends: 4
     gpus_per_node: 8
 
   backend:
@@ -133,7 +138,7 @@ base:
 # TP4 prefill mode: tensor-parallel instead of data-parallel for prefill
 override_tp4:
   name: "b200-fp4-low-latency-tp4-1p-tp8-1d"
-  resources:
+  frontend:
     num_additional_frontends: 2
   backend:
     sglang_config:
@@ -142,25 +147,83 @@ override_tp4:
         expert-parallel-size: 1
         enable-dp-attention: null
         enable-dp-lm-head: null
-        fp4-gemm-backend: null
+      decode:
+        expert-parallel-size: 1
   benchmark:
     concurrencies: "4x8x16x64"
 
 
-# dep4 scale sweep: low-latency (1p1d, 1p5d, 2p5d) and max-throughput (4p1d, 7p2d)
-# Note: 4p1d has no num_additional_frontends — set to null to delete the base value
-zip_override_scale:
+# dep4 low-latency scale sweep: 1p1d, 1p5d, 2p5d
+zip_override_lowlat:
   name:
     - "b200-fp4-low-latency-dep4-1p-tep8-1d"
     - "b200-fp4-low-latency-dep4-1p-tep8-5d"
     - "b200-fp4-low-latency-dep4-2p-tep8-5d"
-    - "b200-fp4-max-tpt-dep4-4p-dep8-1d"
-    - "b200-fp4-max-tpt-dep4-7p-dep8-2d"
   resources:
-    prefill_nodes: [1, 1, 2, 4, 7]
-    prefill_workers: [1, 1, 2, 4, 7]
-    decode_nodes: [1, 5, 5, 1, 2]
-    decode_workers: [1, 5, 5, 1, 2]
-    num_additional_frontends: [4, 4, 4, null, 4]
+    prefill_nodes: [1, 1, 2]
+    prefill_workers: [1, 1, 2]
+    decode_nodes: [1, 5, 5]
+    decode_workers: [1, 5, 5]
   benchmark:
-    concurrencies: ["64x128", "8", "4x128", "1024", "1024x2048"]
+    concurrencies: ["64x128", "8", "4x128"]
+
+
+# Max-throughput 4p1d: dep8 decode, no frontends config, SGLANG_FLASHINFER_FP4_GEMM_BACKEND,
+# mem-fraction=0.75, no fp4-gemm-backend in sglang_config
+override_maxtpt_4p1d:
+  name: "b200-fp4-max-tpt-dep4-4p-dep8-1d"
+  frontend: null
+  resources:
+    prefill_nodes: 4
+    prefill_workers: 4
+    decode_nodes: 1
+    decode_workers: 1
+  backend:
+    decode_environment:
+      SGLANG_MOE_NVFP4_DISPATCH: "1"
+      SGLANG_FLASHINFER_FP4_GEMM_BACKEND: "cutlass"
+    sglang_config:
+      prefill:
+        max-running-requests: 1024
+        fp4-gemm-backend: null
+      decode:
+        mem-fraction-static: 0.75
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 1024
+        cuda-graph-max-bs: 1024
+        fp4-gemm-backend: null
+  benchmark:
+    concurrencies: "1024"
+
+
+# Max-throughput 7p2d: dep8 decode, with frontends, SGLANG_MOE_NVFP4_DISPATCH only,
+# flashinfer_cutlass backend, max-running-requests=2048 for decode
+override_maxtpt_7p2d:
+  name: "b200-fp4-max-tpt-dep4-7p-dep8-2d"
+  resources:
+    prefill_nodes: 7
+    prefill_workers: 7
+    decode_nodes: 2
+    decode_workers: 2
+  backend:
+    decode_environment:
+      SGLANG_MOE_NVFP4_DISPATCH: "1"
+    sglang_config:
+      prefill:
+        max-prefill-tokens: 65536
+        chunked-prefill-size: 65536
+        max-running-requests: 1024
+        fp4-gemm-backend: "flashinfer_cutlass"
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 2048
+        cuda-graph-max-bs: 1024
+        fp4-gemm-backend: "flashinfer_cutlass"
+  benchmark:
+    concurrencies: "1024x2048"

--- a/recipes/b200-fp4/8k1k-stp.yaml
+++ b/recipes/b200-fp4/8k1k-stp.yaml
@@ -1,14 +1,15 @@
 # B200-FP4 8k1k STP — all variants in one file
 #
-# Two prefill modes:
-#   dep4 (default): DP4 prefill — tensor-parallel-size=4, data-parallel-size=4
-#   tp4  (override_tp4): TP4 prefill — tensor-parallel-size=4, data-parallel-size=1
+# Three modes:
+#   dep4 low-lat (default): DP4 prefill + tep8 decode (DP=1)
+#   tp4  (override_tp4):    TP4 prefill (DP=1, EP=1) — for low-latency single-node
+#   dep8 max-tpt (override_maxtpt_7p2d): DP8 decode, large-scale 7p2d
 #
 # Usage:
-#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml                       # all 4 dep4 variants
-#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml:override_tp4          # tp4 variant
-#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml:zip_override_scale[0] # 1p1d dep4 only
-#   srtctl dry-run -f recipes/b200-fp4/8k1k-stp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml                         # all 5 variants
+#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml:override_tp4            # tp4 variant
+#   srtctl apply  -f recipes/b200-fp4/8k1k-stp.yaml:zip_override_lowlat[0]  # 1p1d dep4 only
+#   srtctl dry-run -f recipes/b200-fp4/8k1k-stp.yaml                        # preview
 
 base:
   name: "b200-fp4-stp-8k1k"
@@ -18,6 +19,9 @@ base:
     container: "dynamo-sglang"
     precision: "fp4"
 
+  frontend:
+    num_additional_frontends: 4
+
   resources:
     gpu_type: "b200"
     prefill_nodes: 1
@@ -25,7 +29,6 @@ base:
     gpus_per_prefill: 4
     decode_nodes: 1
     decode_workers: 1
-    num_additional_frontends: 4
     gpus_per_node: 8
 
   backend:
@@ -84,6 +87,7 @@ base:
         kv-cache-dtype: "fp8_e4m3"
         moe-runner-backend: "flashinfer_trtllm"
         moe-dense-tp-size: 1
+        fp4-gemm-backend: "flashinfer_trtllm"
         stream-interval: 30
         watchdog-timeout: 1000000
         enable-flashinfer-allreduce-fusion: true
@@ -106,6 +110,7 @@ base:
         attention-backend: "trtllm_mla"
         kv-cache-dtype: "fp8_e4m3"
         moe-runner-backend: "flashinfer_trtllm"
+        fp4-gemm-backend: "flashinfer_trtllm"
         stream-interval: 30
         watchdog-timeout: 1000000
         enable-flashinfer-allreduce-fusion: true
@@ -125,7 +130,7 @@ base:
 # TP4 prefill mode: tensor-parallel instead of data-parallel for prefill
 override_tp4:
   name: "b200-fp4-low-latency-tp4-1p-tp8-1d"
-  resources:
+  frontend:
     num_additional_frontends: 2
   backend:
     sglang_config:
@@ -134,21 +139,51 @@ override_tp4:
         expert-parallel-size: 1
         enable-dp-attention: null
         enable-dp-lm-head: null
+      decode:
+        expert-parallel-size: 1
   benchmark:
     concurrencies: "4x8x16x64"
 
 
-# dep4 scale sweep: low-latency (1p1d, 1p5d, 2p5d) and max-throughput (7p2d)
-zip_override_scale:
+# dep4 low-latency scale sweep: 1p1d, 1p5d, 2p5d
+zip_override_lowlat:
   name:
     - "b200-fp4-low-latency-dep4-1p-tep8-1d"
     - "b200-fp4-low-latency-dep4-1p-tep8-5d"
     - "b200-fp4-low-latency-dep4-2p-tep8-5d"
-    - "b200-fp4-max-tpt-dep4-7p-dep8-2d"
   resources:
-    prefill_nodes: [1, 1, 2, 7]
-    prefill_workers: [1, 1, 2, 7]
-    decode_nodes: [1, 5, 5, 2]
-    decode_workers: [1, 5, 5, 2]
+    prefill_nodes: [1, 1, 2]
+    prefill_workers: [1, 1, 2]
+    decode_nodes: [1, 5, 5]
+    decode_workers: [1, 5, 5]
   benchmark:
-    concurrencies: ["64x128", "8", "4x128", "1024x2048"]
+    concurrencies: ["64x128", "8", "4x128"]
+
+
+# Max-throughput 7p2d: dep8 decode, large-scale, flashinfer_cutlass backend
+override_maxtpt_7p2d:
+  name: "b200-fp4-max-tpt-dep4-7p-dep8-2d"
+  resources:
+    prefill_nodes: 7
+    prefill_workers: 7
+    decode_nodes: 2
+    decode_workers: 2
+  backend:
+    decode_environment:
+      SGLANG_MOE_NVFP4_DISPATCH: "1"
+    sglang_config:
+      prefill:
+        max-prefill-tokens: 65536
+        chunked-prefill-size: 65536
+        max-running-requests: 1024
+        fp4-gemm-backend: "flashinfer_cutlass"
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 2048
+        cuda-graph-max-bs: 1024
+        fp4-gemm-backend: "flashinfer_cutlass"
+  benchmark:
+    concurrencies: "1024x2048"

--- a/recipes/b200-fp8/1k1k-mtp.yaml
+++ b/recipes/b200-fp8/1k1k-mtp.yaml
@@ -1,9 +1,16 @@
 # B200-FP8 1k1k MTP — all scale variants in one file
 #
+# Two parallelism modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings
+#
+# Note: max-tpt DP=8 does NOT raise max-running-requests for MTP (stays 512).
+#       override_maxtpt_1p2d is a special case: speculative-num-steps=1, draft-tokens=2.
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp8/1k1k-mtp.yaml                       # all 6 variants
-#   srtctl apply  -f recipes/b200-fp8/1k1k-mtp.yaml:zip_override_scale[0] # 1p1d low-lat
-#   srtctl dry-run -f recipes/b200-fp8/1k1k-mtp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp8/1k1k-mtp.yaml                               # all 6 variants
+#   srtctl apply  -f recipes/b200-fp8/1k1k-mtp.yaml:zip_override_lowlat[0]       # 1p1d low-lat only
+#   srtctl dry-run -f recipes/b200-fp8/1k1k-mtp.yaml                             # preview
 
 base:
   name: "b200-fp8-mtp-1k1k"
@@ -117,25 +124,63 @@ base:
     req_rate: "inf"
 
 
-# Sweep: low-latency (1p1d, 1p3d) and max-throughput (1p1d, 1p2d, 1p5d, 2p5d)
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p1d and 1p3d
+zip_override_lowlat:
   name:
     - "b200-fp8-low-latency-tep8-1p-1d"
     - "b200-fp8-low-latency-tep8-1p-3d"
+  resources:
+    decode_nodes: [1, 3]
+    decode_workers: [1, 3]
+  benchmark:
+    concurrencies: ["4x64", "4x8x16x32x128"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p1d/1p5d/2p5d
+# Note: max-running-requests stays at 512 for MTP (unlike STP)
+zip_override_maxtpt:
+  name:
     - "b200-fp8-max-tpt-dep8-1p-1d"
-    - "b200-fp8-max-tpt-dep8-1p-2d"
     - "b200-fp8-max-tpt-dep8-1p-5d"
     - "b200-fp8-max-tpt-dep8-2p-5d"
   resources:
-    prefill_nodes: [1, 1, 1, 1, 1, 2]
-    prefill_workers: [1, 1, 1, 1, 1, 2]
-    decode_nodes: [1, 3, 1, 2, 5, 5]
-    decode_workers: [1, 3, 1, 2, 5, 5]
+    prefill_nodes: [1, 1, 2]
+    prefill_workers: [1, 1, 2]
+    decode_nodes: [1, 5, 5]
+    decode_workers: [1, 5, 5]
+  backend:
+    sglang_config:
+      prefill:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
   benchmark:
-    concurrencies:
-      - "4x64"
-      - "4x8x16x32x128"
-      - "512x1024x2048x4096"
-      - "512x1024x2048"
-      - "512x4096"
-      - "1024x2048x4096"
+    concurrencies: ["512x1024x2048x4096", "512x4096", "1024x2048x4096"]
+
+
+# Special case: 1p2d has speculative-num-steps=1 and draft-tokens=2 (vs 2/3 for all others)
+override_maxtpt_1p2d:
+  name: "b200-fp8-max-tpt-dep8-1p-2d"
+  resources:
+    decode_nodes: 2
+    decode_workers: 2
+  backend:
+    sglang_config:
+      prefill:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        speculative-num-steps: 1
+        speculative-num-draft-tokens: 2
+  benchmark:
+    concurrencies: "512x1024x2048"

--- a/recipes/b200-fp8/1k1k-stp.yaml
+++ b/recipes/b200-fp8/1k1k-stp.yaml
@@ -1,9 +1,13 @@
 # B200-FP8 1k1k STP — all scale variants in one file
 #
+# Two parallelism modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp8/1k1k-stp.yaml                       # all 4 variants
-#   srtctl apply  -f recipes/b200-fp8/1k1k-stp.yaml:zip_override_scale[0] # 1p1d only
-#   srtctl dry-run -f recipes/b200-fp8/1k1k-stp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp8/1k1k-stp.yaml                          # all 4 variants
+#   srtctl apply  -f recipes/b200-fp8/1k1k-stp.yaml:zip_override_lowlat[0]  # 1p1d low-lat only
+#   srtctl dry-run -f recipes/b200-fp8/1k1k-stp.yaml                        # preview
 
 base:
   name: "b200-fp8-stp-1k1k"
@@ -110,17 +114,42 @@ base:
     req_rate: "inf"
 
 
-# Sweep all scale variants: low-latency 1p1d/1p3d and max-throughput 1p5d/2p5d
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p1d and 1p3d
+zip_override_lowlat:
   name:
     - "b200-fp8-low-latency-tep8-1p-1d"
     - "b200-fp8-low-latency-tep8-1p-3d"
+  resources:
+    decode_nodes: [1, 3]
+    decode_workers: [1, 3]
+  benchmark:
+    concurrencies: ["4", "16x32x64x128x256"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p5d and 2p5d
+zip_override_maxtpt:
+  name:
     - "b200-fp8-max-tpt-dep8-1p-5d"
     - "b200-fp8-max-tpt-dep8-2p-5d"
   resources:
-    prefill_nodes: [1, 1, 1, 2]
-    prefill_workers: [1, 1, 1, 2]
-    decode_nodes: [1, 3, 5, 5]
-    decode_workers: [1, 3, 5, 5]
+    prefill_nodes: [1, 2]
+    prefill_workers: [1, 2]
+    decode_nodes: [5, 5]
+    decode_workers: [5, 5]
+  backend:
+    sglang_config:
+      prefill:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 1024
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 1024
+        cuda-graph-max-bs: 1024
   benchmark:
-    concurrencies: ["4", "16x32x64x128x256", "1024", "2048"]
+    concurrencies: ["1024", "2048"]

--- a/recipes/b200-fp8/8k1k-mtp.yaml
+++ b/recipes/b200-fp8/8k1k-mtp.yaml
@@ -1,9 +1,15 @@
 # B200-FP8 8k1k MTP — all scale variants in one file
 #
+# Two parallelism modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings
+#
+# Note: max-running-requests stays at 512 for all MTP variants (unlike STP).
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp8/8k1k-mtp.yaml                       # all 6 variants
-#   srtctl apply  -f recipes/b200-fp8/8k1k-mtp.yaml:zip_override_scale[0] # 1p1d low-lat
-#   srtctl dry-run -f recipes/b200-fp8/8k1k-mtp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp8/8k1k-mtp.yaml                          # all 6 variants
+#   srtctl apply  -f recipes/b200-fp8/8k1k-mtp.yaml:zip_override_lowlat[0]  # 1p1d low-lat only
+#   srtctl dry-run -f recipes/b200-fp8/8k1k-mtp.yaml                        # preview
 
 base:
   name: "b200-fp8-mtp-8k1k"
@@ -117,25 +123,41 @@ base:
     req_rate: "inf"
 
 
-# Sweep: low-latency (1p1d, 1p4d, 1p6d) and max-throughput (1p1d, 1p2d, 2p1d)
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p1d/1p4d/1p6d
+zip_override_lowlat:
   name:
     - "b200-fp8-low-latency-tep8-1p-1d"
     - "b200-fp8-low-latency-tep8-1p-4d"
     - "b200-fp8-low-latency-tep8-1p-6d"
+  resources:
+    decode_nodes: [1, 4, 6]
+    decode_workers: [1, 4, 6]
+  benchmark:
+    concurrencies: ["16x32x64", "8x256", "4x8x16x256"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p1d/1p2d/2p1d
+# Note: max-running-requests stays at 512 for MTP
+zip_override_maxtpt:
+  name:
     - "b200-fp8-max-tpt-dep8-1p-1d"
     - "b200-fp8-max-tpt-dep8-1p-2d"
     - "b200-fp8-max-tpt-dep8-2p-1d"
   resources:
-    prefill_nodes: [1, 1, 1, 1, 1, 2]
-    prefill_workers: [1, 1, 1, 1, 1, 2]
-    decode_nodes: [1, 4, 6, 1, 2, 1]
-    decode_workers: [1, 4, 6, 1, 2, 1]
+    prefill_nodes: [1, 1, 2]
+    prefill_workers: [1, 1, 2]
+    decode_nodes: [1, 2, 1]
+    decode_workers: [1, 2, 1]
+  backend:
+    sglang_config:
+      prefill:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
   benchmark:
-    concurrencies:
-      - "16x32x64"
-      - "8x256"
-      - "4x8x16x256"
-      - "256"
-      - "128x256x512x1024"
-      - "128x512"
+    concurrencies: ["256", "128x256x512x1024", "128x512"]

--- a/recipes/b200-fp8/8k1k-stp.yaml
+++ b/recipes/b200-fp8/8k1k-stp.yaml
@@ -1,9 +1,13 @@
 # B200-FP8 8k1k STP — all scale variants in one file
 #
+# Two parallelism modes:
+#   tep8 (low-latency): DP=1 decode — base config
+#   dep8 (max-tpt):     DP=8 decode — zip_override_maxtpt adds DP settings
+#
 # Usage:
-#   srtctl apply  -f recipes/b200-fp8/8k1k-stp.yaml                       # all 5 variants
-#   srtctl apply  -f recipes/b200-fp8/8k1k-stp.yaml:zip_override_scale[0] # 1p1d low-lat
-#   srtctl dry-run -f recipes/b200-fp8/8k1k-stp.yaml                      # preview
+#   srtctl apply  -f recipes/b200-fp8/8k1k-stp.yaml                          # all 5 variants
+#   srtctl apply  -f recipes/b200-fp8/8k1k-stp.yaml:zip_override_lowlat[0]  # 1p1d low-lat only
+#   srtctl dry-run -f recipes/b200-fp8/8k1k-stp.yaml                        # preview
 
 base:
   name: "b200-fp8-stp-8k1k"
@@ -110,18 +114,43 @@ base:
     req_rate: "inf"
 
 
-# Sweep: low-latency (1p1d, 1p4d, 1p6d) and max-throughput (1p1d, 2p1d)
-zip_override_scale:
+# Low-latency variants: tep8 decode (DP=1), scale sweep 1p1d/1p4d/1p6d
+zip_override_lowlat:
   name:
     - "b200-fp8-low-latency-tep8-1p-1d"
     - "b200-fp8-low-latency-tep8-1p-4d"
     - "b200-fp8-low-latency-tep8-1p-6d"
+  resources:
+    decode_nodes: [1, 4, 6]
+    decode_workers: [1, 4, 6]
+  benchmark:
+    concurrencies: ["4x32x64", "64", "32"]
+
+
+# Max-throughput variants: dep8 decode (DP=8), scale sweep 1p1d and 2p1d
+zip_override_maxtpt:
+  name:
     - "b200-fp8-max-tpt-dep8-1p-1d"
     - "b200-fp8-max-tpt-dep8-2p-1d"
   resources:
-    prefill_nodes: [1, 1, 1, 1, 2]
-    prefill_workers: [1, 1, 1, 1, 2]
-    decode_nodes: [1, 4, 6, 1, 1]
-    decode_workers: [1, 4, 6, 1, 1]
+    prefill_nodes: [1, 2]
+    prefill_workers: [1, 2]
+    decode_nodes: [1, 1]
+    decode_workers: [1, 1]
+  backend:
+    sglang_config:
+      prefill:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 1024
+      decode:
+        data-parallel-size: 8
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        max-running-requests: 1024
+        cuda-graph-max-bs: 1024
   benchmark:
-    concurrencies: ["4x32x64", "64", "32", "128", "256"]
+    concurrencies: ["128", "256"]

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -104,7 +104,7 @@ class TestGenerateOverrideConfigs:
         suffixes = [s for s, _ in variants]
         assert suffixes == ["small", "tp_0", "tp_1"]
 
-        # override auto-name and deep-merge
+        # override auto-name and deep-merge (no explicit name in override)
         assert variants[0][1]["name"] == "base-job_small"
         assert variants[0][1]["resources"]["decode_nodes"] == 2
 


### PR DESCRIPTION
## Summary

- Reduce 40 individual B200 recipe files to 8 override files (one per precision × isl × stp/mtp)
- Fix `num_additional_frontends` placement: was incorrectly under `resources:`, now correctly under `frontend:` (resolves schema validation errors)
- Fix `override_tp4`: remove erroneous `fp4-gemm-backend: null` and add missing `decode: expert-parallel-size: 1`
- Separate low-latency and max-throughput variants into distinct `zip_override_lowlat` / `zip_override_maxtpt` groups, each carrying correct sglang_config overrides (DP=8, moe-dense-tp-size, env vars, etc.)
- FP8 MTP: keep `max-running-requests=512` in max-tpt (STP raises to 1024, MTP does not — preserves original behavior)
- FP8 1k1k MTP: add `override_maxtpt_1p2d` special case (`speculative-num-steps=1`, `speculative-num-draft-tokens=2`)
- FP4 1k1k MTP max-tpt: per-variant `mem-fraction-static: [0.75, 0.85]`
- Fix `generate_override_configs`: honor explicit `name:` field in `override_*` dicts instead of always auto-generating `{base_name}_{suffix}`; add test coverage

## File summary

| File | Variants |
|------|----------|
| `recipes/b200-fp8/1k1k-stp.yaml` | 4 (1p1d/1p3d low-lat, 1p5d/2p5d max-tpt) |
| `recipes/b200-fp8/1k1k-mtp.yaml` | 6 (+ special 1p2d spec case) |
| `recipes/b200-fp8/8k1k-stp.yaml` | 5 (1p1d/1p4d/1p6d low-lat, 1p1d/2p1d max-tpt) |
| `recipes/b200-fp8/8k1k-mtp.yaml` | 6 |
| `recipes/b200-fp4/1k1k-stp.yaml` | 4 (1p5d/1p6d low-lat, 1p1d/1p2d max-tpt) |
| `recipes/b200-fp4/1k1k-mtp.yaml` | 4 |
| `recipes/b200-fp4/8k1k-stp.yaml` | 5 (tp4 + 1p1d/1p5d/2p5d low-lat + 7p2d max-tpt) |
| `recipes/b200-fp4/8k1k-mtp.yaml` | 6 (tp4 + 3 low-lat + 4p1d/7p2d max-tpt) |

## Test plan

- [x] `make check` passes (329 tests)
- [x] `srtctl dry-run` on all 8 files shows correct variant counts and names with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment configurations for B200-FP4 and B200-FP8 GPUs supporting 1k1k and 8k1k model sizes.
  * Introduced low-latency and max-throughput variants with multiple scale configurations for flexible deployment options.
  * Enabled explicit naming of configuration variants for improved clarity and selection.

* **Tests**
  * Added test coverage for explicit variant naming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->