### PR TITLE
fix: honor explicit name: field in override_* sections

### DIFF
--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -313,18 +313,22 @@ def generate_override_configs(
             all_selectors = ", ".join([*override_keys, *[f"{k}[i]" for k in zip_keys]]) or "(none)"
             raise ValueError(f"Override '{selector}' not found in config. Available: {all_selectors}")
         suffix = selector[len("override_") :]
-        merged = deep_merge(base, raw_config[selector])
-        base_name = base.get("name", "unnamed")
-        merged["name"] = f"{base_name}_{suffix}"
+        override_dict = raw_config[selector]
+        merged = deep_merge(base, override_dict)
+        if "name" not in override_dict:
+            base_name = base.get("name", "unnamed")
+            merged["name"] = f"{base_name}_{suffix}"
         return [(suffix, merged)]
 
     # selector=None: all overrides + all zip groups (sorted for determinism); base excluded
     configs: list[tuple[str, dict[str, Any]]] = []
     for key in override_keys:
         suffix = key[len("override_") :]
-        merged = deep_merge(base, raw_config[key])
-        base_name = base.get("name", "unnamed")
-        merged["name"] = f"{base_name}_{suffix}"
+        override_dict = raw_config[key]
+        merged = deep_merge(base, override_dict)
+        if "name" not in override_dict:
+            base_name = base.get("name", "unnamed")
+            merged["name"] = f"{base_name}_{suffix}"
         configs.append((suffix, merged))
     for key in zip_keys:
         group_name = key[len("zip_override_") :]

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -133,6 +133,21 @@ class TestGenerateOverrideConfigs:
         with pytest.raises(ValueError, match="out of range"):
             generate_override_configs(_RAW, selector="zip_override_tp[5]")
 
+    def test_override_explicit_name(self) -> None:
+        """An explicit 'name' in override_* is used instead of auto-generated name."""
+        raw = {
+            "base": {"name": "base-job", "resources": {"decode_nodes": 8}},
+            "override_custom": {"name": "my-custom-name", "resources": {"decode_nodes": 4}},
+        }
+        variants = generate_override_configs(raw)
+        assert len(variants) == 1
+        assert variants[0][1]["name"] == "my-custom-name"
+        assert variants[0][1]["resources"]["decode_nodes"] == 4
+
+        # Selector form also respects explicit name
+        r = generate_override_configs(raw, selector="override_custom")
+        assert r[0][1]["name"] == "my-custom-name"
+
 
 # =============================================================================
 # TestIsOverrideConfig


### PR DESCRIPTION
## Summary

- `generate_override_configs` previously ignored any `name:` field inside an `override_*` dict, always overwriting it with an auto-generated `{base_name}_{suffix}`. Now the auto-generated name is only used as a fallback when no `name:` is provided — consistent with how `zip_override_*` already handles named variants.
- Adds test coverage for the new behavior.

## Example

```yaml
base:
  name: "b200-fp4-mtp-8k1k"
  ...

override_maxtpt_4p1d:
  name: "b200-fp4-max-tpt-dep4-4p-dep8-1d"  # now respected
  ...
```

**Before:** dry-run showed `b200-fp4-mtp-8k1k_maxtpt_4p1d`
**After:** dry-run shows `b200-fp4-max-tpt-dep4-4p-dep8-1d`

## Test plan

- [x] `make check` passes (335 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Override configurations now properly respect explicitly provided names. Previously, user-supplied names were being replaced with auto-generated identifiers. Names are now correctly preserved during configuration merging.

* **Tests**
  * Added test coverage verifying that explicit names in override configurations are correctly preserved instead of being replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->