### PR TITLE
Fix override submission runtime config handling

### DIFF
--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -37,9 +37,7 @@ from rich.table import Table
 from srtctl.core.config import (
     generate_override_configs,
     get_srtslurm_setting,
-    load_cluster_config,
     load_config,
-    resolve_config_with_defaults,
 )
 from srtctl.core.schema import SrtConfig
 from srtctl.core.status import create_job_record
@@ -156,6 +154,7 @@ def generate_minimal_sbatch_script(
     config_path: Path,
     setup_script: str | None = None,
     output_dir: Path | None = None,
+    runtime_config_filename: str = "config.yaml",
 ) -> str:
     """Generate minimal sbatch script that calls the Python orchestrator.
 
@@ -167,6 +166,7 @@ def generate_minimal_sbatch_script(
         config_path: Path to the YAML config file
         setup_script: Optional setup script override (passed via env var)
         output_dir: Custom output directory (CLI flag, highest priority)
+        runtime_config_filename: Config file name under OUTPUT_DIR used by do_sweep
 
     Returns:
         Rendered sbatch script as string
@@ -215,6 +215,7 @@ def generate_minimal_sbatch_script(
         partition=config.slurm.partition or os.environ.get("SLURM_PARTITION", "default"),
         time_limit=config.slurm.time_limit or "01:00:00",
         config_path=str(config_path.resolve()),
+        runtime_config_filename=runtime_config_filename,
         timestamp=timestamp,
         use_gpus_per_node_directive=get_srtslurm_setting("use_gpus_per_node_directive", True),
         use_segment_sbatch_directive=get_srtslurm_setting("use_segment_sbatch_directive", True),
@@ -252,8 +253,8 @@ def submit_with_orchestrator(
         output_dir: Custom output directory (CLI flag, highest priority)
         variant_suffix: If set (e.g. "base", "lowmem"), also save config_path
                         as config_{variant_suffix}.yaml in the job output dir.
-        source_config_path: If set, saved as config.yaml instead of config_path.
-                            Used for override jobs to preserve the original file.
+        source_config_path: If set, save the original source YAML as config.yaml
+                            while the job executes a resolved variant config.
 
     Returns:
         job_id string on success, None for dry_run.
@@ -262,11 +263,16 @@ def submit_with_orchestrator(
     if config is None:
         config = load_config(config_path)
 
+    runtime_config_filename = "config.yaml"
+    if source_config_path:
+        runtime_config_filename = f"config_{variant_suffix}.yaml" if variant_suffix else "config_resolved.yaml"
+
     script_content = generate_minimal_sbatch_script(
         config=config,
         config_path=config_path,
         setup_script=setup_script,
         output_dir=output_dir,
+        runtime_config_filename=runtime_config_filename,
     )
 
     if dry_run:
@@ -322,6 +328,8 @@ def submit_with_orchestrator(
         shutil.copy(source_config_path or config_path, job_output_dir / "config.yaml")
         if variant_suffix:
             shutil.copy(config_path, job_output_dir / f"config_{variant_suffix}.yaml")
+        elif source_config_path:
+            shutil.copy(config_path, job_output_dir / runtime_config_filename)
         shutil.copy(script_path, job_output_dir / "sbatch_script.sh")
 
         job_name = get_job_name(config)
@@ -417,7 +425,8 @@ def submit_single(
         tags: Optional list of tags
         output_dir: Custom output directory (CLI flag, highest priority)
         variant_suffix: If set, also save config as config_{suffix}.yaml in job output dir.
-        source_config_path: If set, saved as config.yaml (original file for override jobs).
+        source_config_path: If set, saved as config.yaml while execution uses the
+                            resolved variant config.
 
     Returns:
         job_id string on success, None for dry_run.
@@ -733,26 +742,29 @@ def submit_override(
         )
         console.print()
 
-    cluster_config = load_cluster_config()
+    from srtctl.core.config import resolve_override_yaml
+    from srtctl.core.yaml_utils import dump_yaml_with_comments
 
-    for i, (suffix, config_dict) in enumerate(override_configs, 1):
+    resolved_variants = resolve_override_yaml(config_path, selector=selector)
+
+    for i, (suffix, config_cm) in enumerate(resolved_variants, 1):
         variant_label = "base" if suffix == "base" else f"override_{suffix}"
-        job_name = config_dict.get("name", "unnamed")
+        job_name = config_cm.get("name", "unnamed")
 
         if dry_run:
             console.print(f"[bold cyan][{i}/{len(override_configs)}][/] {variant_label}: {job_name}")
 
-        resolved = resolve_config_with_defaults(config_dict, cluster_config)
-
         logger.info(f"Override variant: {variant_label} -> {job_name}")
 
-        # Write resolved config next to the original override YAML so the
-        # SLURM job can read it when it starts (sbatch script embeds the path).
+        # Write the comment-preserving resolved config next to the original
+        # override YAML so the SLURM job can execute that exact variant.
         variant_file = config_path.parent / f"{config_path.stem}_{suffix}.yaml"
         with open(variant_file, "w") as f:
-            yaml.dump(resolved, f, default_flow_style=False, sort_keys=False)
+            dump_yaml_with_comments(config_cm, f)
 
-        if "sweep" in resolved:
+        config = load_config(variant_file)
+
+        if "sweep" in config_cm:
             try:
                 submit_sweep(
                     config_path=variant_file,
@@ -766,7 +778,6 @@ def submit_override(
                 with contextlib.suppress(OSError):
                     variant_file.unlink()
         else:
-            config = SrtConfig.Schema().load(resolved)
             submit_single(
                 config_path=variant_file,
                 config=config,

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -427,6 +427,10 @@ def resolve_override_yaml(
         if override_key in raw_cm and isinstance(raw_cm[override_key], CommentedMap):
             # Regular override: merge CommentedMaps so override comments are kept.
             result_cm = comment_aware_merge(base_cm, raw_cm[override_key])
+            # Preserve auto-generated fields from the existing override expansion,
+            # such as the synthesized name when the override does not set one.
+            if "name" in merged_plain:
+                result_cm["name"] = merged_plain["name"]
         else:
             # zip_override variant (values were lists → now scalars) or any
             # other case: merge the plain resolved dict into the base CommentedMap

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -62,7 +62,9 @@ echo "Start: $(date)"
 echo "=========================================="
 echo ""
 
-# Config already copied to OUTPUT_DIR/config.yaml by Python at submission time (submit.py)
+# submit.py always copies the original submission config to OUTPUT_DIR/config.yaml.
+# For override jobs it also writes the resolved runtime config below.
+echo "Runtime config: ${OUTPUT_DIR}/{{ runtime_config_filename }}"
 
 # Get head node
 HEAD_NODE=$(scontrol show hostnames ${SLURM_NODELIST} | head -n1)
@@ -96,7 +98,7 @@ echo ""
 # Output goes to SLURM's --output (sweep_%j.log)
 set +e  # Temporarily disable exit-on-error to capture exit code
 cd "${SRTCTL_SOURCE}"
-uv run --python 3.12 --no-dev -m srtctl.cli.do_sweep "${OUTPUT_DIR}/config.yaml"
+uv run --python 3.12 --no-dev -m srtctl.cli.do_sweep "${OUTPUT_DIR}/{{ runtime_config_filename }}"
 EXIT_CODE=$?
 set -e  # Re-enable exit-on-error
 

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -3,21 +3,20 @@
 
 """Tests for config override (base + override_* + zip_override_*) functionality."""
 
+import textwrap
+from io import StringIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-
-import textwrap
-
+from ruamel.yaml import YAML as RuamelYAML
 from ruamel.yaml.comments import CommentedMap
 
-from srtctl.cli.submit import is_override_config, parse_config_arg, resolve_override_cmd, submit_override
+from srtctl.cli.submit import is_override_config, parse_config_arg, resolve_override_cmd, submit_override, submit_single
 from srtctl.core.config import deep_merge, expand_zip_override, generate_override_configs, resolve_override_yaml
-from srtctl.core.yaml_utils import comment_aware_merge, load_yaml_with_comments
-
+from srtctl.core.yaml_utils import comment_aware_merge
 
 # =============================================================================
 # TestDeepMerge
@@ -35,20 +34,20 @@ class TestDeepMerge:
             "extra_mount": ["/data:/data"],
         }
         override = {
-            "resources": {"decode_nodes": 4},                          # scalar override
-            "benchmark": {"concurrencies": [4096]},                    # list replace
+            "resources": {"decode_nodes": 4},  # scalar override
+            "benchmark": {"concurrencies": [4096]},  # list replace
             "backend": {"sglang_config": {"prefill": {"tp-size": 64}}},  # nested merge
-            "extra_mount": None,                                        # null → delete
-            "environment": {"NEW_VAR": "value"},                        # new key
+            "extra_mount": None,  # null → delete
+            "environment": {"NEW_VAR": "value"},  # new key
         }
         result = deep_merge(base, override)
-        assert result["name"] == "old"                                             # untouched
-        assert result["resources"]["decode_nodes"] == 4                            # scalar
-        assert result["benchmark"]["concurrencies"] == [4096]                      # list replace
-        assert result["backend"]["sglang_config"]["prefill"]["tp-size"] == 64      # nested
+        assert result["name"] == "old"  # untouched
+        assert result["resources"]["decode_nodes"] == 4  # scalar
+        assert result["benchmark"]["concurrencies"] == [4096]  # list replace
+        assert result["backend"]["sglang_config"]["prefill"]["tp-size"] == 64  # nested
         assert result["backend"]["sglang_config"]["prefill"]["trust-remote-code"] is True  # preserved
-        assert "extra_mount" not in result                                         # null delete
-        assert result["environment"]["NEW_VAR"] == "value"                         # new key
+        assert "extra_mount" not in result  # null delete
+        assert result["environment"]["NEW_VAR"] == "value"  # new key
 
     def test_immutability(self) -> None:
         """Neither base nor override is mutated."""
@@ -185,8 +184,8 @@ class TestWildcardSelector:
         }
         variants = generate_override_configs(raw, selector="*scale*")
         suffixes = [s for s, _ in variants]
-        assert "scale_big" in suffixes   # from override_scale_big
-        assert "scale_0" in suffixes     # from zip_override_scale
+        assert "scale_big" in suffixes  # from override_scale_big
+        assert "scale_0" in suffixes  # from zip_override_scale
         assert "scale_1" in suffixes
 
     def test_glob_all_overrides(self) -> None:
@@ -257,8 +256,8 @@ class TestExpandZipOverride:
                 "sglang_config": {
                     "prefill": {
                         "tensor-parallel-size": [4, 8],
-                        "mem-fraction-static": [0.85],    # broadcast
-                        "trust-remote-code": False,        # scalar passthrough
+                        "mem-fraction-static": [0.85],  # broadcast
+                        "trust-remote-code": False,  # scalar passthrough
                     }
                 }
             },
@@ -274,10 +273,10 @@ class TestExpandZipOverride:
         assert v1["backend"]["sglang_config"]["prefill"]["tensor-parallel-size"] == 8
         assert v0["backend"]["sglang_config"]["prefill"]["mem-fraction-static"] == 0.85  # broadcast
         assert v1["backend"]["sglang_config"]["prefill"]["mem-fraction-static"] == 0.85
-        assert v0["backend"]["sglang_config"]["prefill"]["trust-remote-code"] is False   # scalar
-        assert v0["benchmark"]["concurrencies"] == [4, 8]    # literal list
+        assert v0["backend"]["sglang_config"]["prefill"]["trust-remote-code"] is False  # scalar
+        assert v0["benchmark"]["concurrencies"] == [4, 8]  # literal list
         assert v1["benchmark"]["concurrencies"] == [4, 8, 16]
-        assert v0["resources"]["decode_nodes"] == 8          # base key preserved
+        assert v0["resources"]["decode_nodes"] == 8  # base key preserved
 
     def test_naming_and_immutability(self) -> None:
         """Auto-name, explicit name list, and base not mutated."""
@@ -299,14 +298,18 @@ class TestExpandZipOverride:
     def test_errors(self) -> None:
         """Incompatible lengths and no lists both raise ValueError."""
         with pytest.raises(ValueError, match="Incompatible zip lengths"):
-            expand_zip_override("bad", {
-                "backend": {
-                    "sglang_config": {
-                        "prefill": {"tensor-parallel-size": [4, 8]},
-                        "decode": {"tensor-parallel-size": [4, 8, 16]},
+            expand_zip_override(
+                "bad",
+                {
+                    "backend": {
+                        "sglang_config": {
+                            "prefill": {"tensor-parallel-size": [4, 8]},
+                            "decode": {"tensor-parallel-size": [4, 8, 16]},
+                        }
                     }
-                }
-            }, _ZIP_BASE)
+                },
+                _ZIP_BASE,
+            )
 
         with pytest.raises(ValueError, match="no list values"):
             expand_zip_override("empty", {"backend": {"tp": 4}}, _ZIP_BASE)
@@ -344,43 +347,47 @@ def _write_config(tmp_path: Path, extra: dict[str, Any] | None = None, filename:
 class TestSubmitOverride:
     def test_dry_run(self, tmp_path: Path, capsys: Any) -> None:
         """Dry-run shows correct variant counts for base-only, overrides, zip, and selectors."""
-        cfg = _write_config(tmp_path, {
-            "override_small": {"resources": {"decode_nodes": 2}},
-            "zip_override_tp": {"resources": {"decode_nodes": [1, 2]}},
-        })
+        cfg = _write_config(
+            tmp_path,
+            {
+                "override_small": {"resources": {"decode_nodes": 2}},
+                "zip_override_tp": {"resources": {"decode_nodes": [1, 2]}},
+            },
+        )
 
-        with patch("srtctl.cli.submit.load_cluster_config", return_value=None):
-            # all variants (no selector): override_small + zip_tp_0 + zip_tp_1 = 3 (base excluded)
-            submit_override(cfg, dry_run=True)
-            assert "3 variants" in capsys.readouterr().out
+        # all variants (no selector): override_small + zip_tp_0 + zip_tp_1 = 3 (base excluded)
+        submit_override(cfg, dry_run=True)
+        assert "3 variants" in capsys.readouterr().out
 
-            # zip group only
-            submit_override(cfg, selector="zip_override_tp", dry_run=True)
-            assert "2 variants" in capsys.readouterr().out
+        # zip group only
+        submit_override(cfg, selector="zip_override_tp", dry_run=True)
+        assert "2 variants" in capsys.readouterr().out
 
-            # single zip variant
-            submit_override(cfg, selector="zip_override_tp[0]", dry_run=True)
-            assert "1 variant" in capsys.readouterr().out
+        # single zip variant
+        submit_override(cfg, selector="zip_override_tp[0]", dry_run=True)
+        assert "1 variant" in capsys.readouterr().out
 
-            # single override
-            submit_override(cfg, selector="override_small", dry_run=True)
-            out = capsys.readouterr().out
-            assert "1 variant" in out
-            assert "test-job_small" in out
+        # single override
+        submit_override(cfg, selector="override_small", dry_run=True)
+        out = capsys.readouterr().out
+        assert "1 variant" in out
+        assert "test-job_small" in out
 
     def test_sbatch_call_counts(self, tmp_path: Path) -> None:
         """submit_override calls sbatch the right number of times for each selector."""
-        cfg = _write_config(tmp_path, {
-            "override_small": {"resources": {"decode_nodes": 2}},
-            "zip_override_tp": {"resources": {"decode_nodes": [1, 2]}},
-        })
+        cfg = _write_config(
+            tmp_path,
+            {
+                "override_small": {"resources": {"decode_nodes": 2}},
+                "zip_override_tp": {"resources": {"decode_nodes": [1, 2]}},
+            },
+        )
 
         mock_result = MagicMock()
         mock_result.stdout = "Submitted batch job 99999"
 
         def sbatch_count(selector: str | None = None) -> int:
             with (
-                patch("srtctl.cli.submit.load_cluster_config", return_value=None),
                 patch("subprocess.run", return_value=mock_result) as mock_run,
                 patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
                 patch("srtctl.cli.submit.create_job_record"),
@@ -388,11 +395,111 @@ class TestSubmitOverride:
                 submit_override(cfg, selector=selector, output_dir=tmp_path)
             return sum(1 for c in mock_run.call_args_list if c[0][0][0] == "sbatch")
 
-        assert sbatch_count() == 3               # small + tp_0 + tp_1 (base excluded by default)
+        assert sbatch_count() == 3  # small + tp_0 + tp_1 (base excluded by default)
         assert sbatch_count("base") == 1
         assert sbatch_count("override_small") == 1
         assert sbatch_count("zip_override_tp") == 2
         assert sbatch_count("zip_override_tp[1]") == 1
+
+    def test_selector_submission_keeps_source_and_executes_resolved_variant(self, tmp_path: Path) -> None:
+        """A selected zip override keeps source config.yaml and runs config_<variant>.yaml."""
+        cfg = _write_config(
+            tmp_path,
+            {
+                "zip_override_tp": {"resources": {"decode_nodes": [1, 2]}},
+            },
+        )
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Submitted batch job 99999"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+            patch("srtctl.cli.submit.create_job_record"),
+        ):
+            submit_override(cfg, selector="zip_override_tp[1]", output_dir=tmp_path)
+
+        job_dir = tmp_path / "99999"
+        source_config = yaml.safe_load((job_dir / "config.yaml").read_text())
+        runtime_config = yaml.safe_load((job_dir / "config_tp_1.yaml").read_text())
+        sbatch_script = (job_dir / "sbatch_script.sh").read_text()
+
+        assert "base" in source_config
+        assert "zip_override_tp" in source_config
+
+        assert runtime_config["name"] == "test-job_tp_1"
+        assert runtime_config["resources"]["decode_nodes"] == 2
+        assert "base" not in runtime_config
+        assert "zip_override_tp" not in runtime_config
+        assert 'do_sweep "${OUTPUT_DIR}/config_tp_1.yaml"' in sbatch_script
+
+    def test_selector_submission_preserves_comments_in_resolved_variant(self, tmp_path: Path) -> None:
+        """Override submission reuses resolve_override_yaml so runtime config keeps comments."""
+        cfg = tmp_path / "submit_override.yaml"
+        cfg.write_text(textwrap.dedent("""\
+            base:
+              name: "test-job"
+              model:
+                path: /models/test-model
+                container: test-container.sqsh
+                precision: fp8
+              # resource section
+              resources:
+                gpu_type: h100
+                gpus_per_node: 8
+                prefill_nodes: 1
+                prefill_workers: 1
+                decode_nodes: 1  # one decoder
+                decode_workers: 1
+              benchmark:
+                type: manual
+
+            override_lowmem:
+              resources:
+                decode_nodes: 4
+        """))
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Submitted batch job 99999"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+            patch("srtctl.cli.submit.create_job_record"),
+        ):
+            submit_override(cfg, selector="override_lowmem", output_dir=tmp_path)
+
+        job_dir = tmp_path / "99999"
+        runtime_text = (job_dir / "config_lowmem.yaml").read_text()
+        assert "resource section" in runtime_text
+        assert "decode_nodes: 4" in runtime_text
+
+
+class TestSubmitSingleCompatibility:
+    def test_plain_config_submission_still_uses_config_yaml(self, tmp_path: Path) -> None:
+        """Non-override submissions keep using OUTPUT_DIR/config.yaml at runtime."""
+        cfg = tmp_path / "plain.yaml"
+        cfg.write_text(yaml.dump(MINIMAL_CONFIG, default_flow_style=False))
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Submitted batch job 99999"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+            patch("srtctl.cli.submit.create_job_record"),
+        ):
+            submit_single(config_path=cfg, output_dir=tmp_path)
+
+        job_dir = tmp_path / "99999"
+        copied_config = yaml.safe_load((job_dir / "config.yaml").read_text())
+        sbatch_script = (job_dir / "sbatch_script.sh").read_text()
+
+        assert copied_config["name"] == MINIMAL_CONFIG["name"]
+        assert copied_config["resources"]["decode_nodes"] == MINIMAL_CONFIG["resources"]["decode_nodes"]
+        assert 'do_sweep "${OUTPUT_DIR}/config.yaml"' in sbatch_script
+        assert not (job_dir / "config_base.yaml").exists()
 
 
 # =============================================================================
@@ -403,6 +510,7 @@ class TestSubmitOverride:
 def _cm(src: str) -> CommentedMap:
     """Parse a YAML string into a CommentedMap."""
     from ruamel.yaml import YAML
+
     y = YAML()
     return y.load(src)
 
@@ -440,10 +548,8 @@ class TestCommentAwareMerge:
         """)
         base = _cm(src)
         result = comment_aware_merge(base, {"b": 99})
-        from io import StringIO
-        from ruamel.yaml import YAML
         buf = StringIO()
-        YAML().dump(result, buf)
+        RuamelYAML().dump(result, buf)
         out = buf.getvalue()
         assert "inline a" in out
         assert "inline b" in out
@@ -493,13 +599,11 @@ class TestResolveOverrideYaml:
 
     def test_comments_in_output(self, tmp_path: Path) -> None:
         """Resolved YAML preserves inline and block comments from base."""
-        from io import StringIO
-        from ruamel.yaml import YAML
         path = _write_commented_config(tmp_path)
         variants = resolve_override_yaml(path, selector="override_lowmem")
         _, cm = variants[0]
         buf = StringIO()
-        YAML().dump(cm, buf)
+        RuamelYAML().dump(cm, buf)
         out = buf.getvalue()
         assert "resource section" in out
         assert "eight decoders" in out
@@ -530,7 +634,7 @@ class TestResolveOverrideYaml:
         assert out.exists()
         text = out.read_text()
         assert "resource section" in text  # comment preserved
-        assert "decode_nodes: 4" in text   # override value applied
+        assert "decode_nodes: 4" in text  # override value applied
 
     def test_resolve_override_cmd_stdout(self, tmp_path: Path, capsys: Any) -> None:
         """resolve_override_cmd --stdout prints YAML to stdout."""
@@ -557,11 +661,9 @@ class TestResolveOverrideYaml:
         path = tmp_path / "sep.yaml"
         path.write_text(src)
         variants = resolve_override_yaml(path)
-        from io import StringIO
-        from ruamel.yaml import YAML as _YAML
         for _, cm in variants:
             buf = StringIO()
-            _YAML().dump(cm, buf)
+            RuamelYAML().dump(cm, buf)
             out = buf.getvalue()
             # separator comment must not appear in the resolved output
             assert "separator comment" not in out


### PR DESCRIPTION
## Summary
- keep OUTPUT_DIR/config.yaml as the original submitted override file
- write and execute a resolved config_<variant>.yaml for override submissions
- preserve comments in resolved override variants and add regression coverage for plain and override configs

## Testing
- uv run pytest tests/test_override.py -q
- uv run ruff check src/srtctl/cli/submit.py src/srtctl/core/config.py tests/test_override.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced configuration override handling with preserved comments in YAML files.
  * Improved configuration variant management for job submissions.
  * Runtime configuration path now displayed in job output logs for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->