### PR TITLE
fix: preserve dynamo cargo rustflags during source install

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -727,8 +727,7 @@ class DynamoConfig:
             "cd dynamo && "
             f"{checkout_cmd + ' && ' if checkout_cmd else ''}"
             "cd lib/bindings/python/ && "
-            'export RUSTFLAGS="${RUSTFLAGS:-} -C target-cpu=native" && '
-            "maturin build -o /tmp && "
+            "maturin build --config 'build.rustflags=[\"-C\",\"target-cpu=native\"]' -o /tmp && "
             "pip install /tmp/ai_dynamo_runtime*.whl && "
             "cd /sgl-workspace/dynamo/ && "
             "pip install -e . && "


### PR DESCRIPTION
## Summary
- stop overriding Cargo rustflags via RUSTFLAGS during dynamo source installs
- append -C target-cpu=native via maturin --config so repo-defined rustflags stay intact
- preserve .cargo/config.toml settings such as tokio_unstable for top-of-tree builds

## Verification
- minimal Python import check of DynamoConfig command generation
- pytest not available in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Python package installation build configuration to enable native CPU optimizations during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->