### PR TITLE
Improve prefill and max throughput config perf for B200

### DIFF
--- a/recipes/b200-fp8/8k1k.yaml
+++ b/recipes/b200-fp8/8k1k.yaml
@@ -17,6 +17,9 @@
 base:
   name: "b200-fp8-stp-8k1k"
 
+  dynamo:
+    version: "0.9.1"
+
   model:
     path: "dsr1-fp8"
     container: "dynamo-sglang"
@@ -35,7 +38,6 @@ base:
       TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
       PYTHONUNBUFFERED: "1"
       DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
-      SGLANG_ENABLE_JIT_DEEPGEMM: "false"
       SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
       SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
       SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
@@ -46,11 +48,13 @@ base:
       NCCL_MNNVL_ENABLE: "1"
       NCCL_CUMEM_ENABLE: "1"
       DYN_REQUEST_PLANE: nats
+      CUDA_SCALE_LAUNCH_QUEUES: "4x"
+      SGLANG_PER_TOKEN_GROUP_QUANT_8BIT_V2: "1"
+
     decode_environment:
       TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
       PYTHONUNBUFFERED: "1"
       DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
-      SGLANG_ENABLE_JIT_DEEPGEMM: "false"
       SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
       SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
       SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
@@ -62,6 +66,9 @@ base:
       NCCL_MNNVL_ENABLE: "1"
       NCCL_CUMEM_ENABLE: "1"
       DYN_REQUEST_PLANE: nats
+      CUDA_SCALE_LAUNCH_QUEUES: "4x"
+      SGLANG_PER_TOKEN_GROUP_QUANT_8BIT_V2: "1"
+
     sglang_config:
       prefill:
         # Model configuration
@@ -74,17 +81,18 @@ base:
         disaggregation-transfer-backend: nixl
 
         # Memory and token limits
-        mem-fraction-static: 0.85
-        max-prefill-tokens: 32768
-        chunked-prefill-size: 32768
+        mem-fraction-static: 0.6
+        max-prefill-tokens: 8192
+        chunked-prefill-size: 65536
+        max-running-requests: 8
         context-length: 9600
-        max-running-requests: 512
-        disable-cuda-graph: true
 
         # Parallelism
         tensor-parallel-size: 8
-        data-parallel-size: 1
-        expert-parallel-size: 8
+        data-parallel-size: 8
+        expert-parallel-size: 1
+        enable-dp-attention: true
+        enable-dp-lm-head: true
 
         # Attention
         attention-backend: "trtllm_mla"
@@ -92,13 +100,14 @@ base:
 
         # MoE
         moe-runner-backend: "flashinfer_trtllm"
-        # moe-dense-tp-size: 1
+        moe-dense-tp-size: 1
 
         # Other flags
         stream-interval: 30
         watchdog-timeout: 1000000
         enable-flashinfer-allreduce-fusion: true
         disable-radix-cache: true
+        load-balance-method: "round_robin"
 
       decode:
         # Model configuration
@@ -111,9 +120,7 @@ base:
         disaggregation-transfer-backend: nixl
 
         # Memory and token limits
-        mem-fraction-static: 0.85
-        max-prefill-tokens: 32768
-        chunked-prefill-size: 32768
+        mem-fraction-static: 0.75
         context-length: 9600
         max-running-requests: 512
         cuda-graph-max-bs: 512
@@ -129,7 +136,7 @@ base:
 
         # MoE
         moe-runner-backend: "flashinfer_trtllm"
-        # moe-dense-tp-size: 1
+        moe-dense-tp-size: 1
 
         # Other flags
         stream-interval: 30
@@ -193,28 +200,23 @@ zip_override_stp_maxtpt:
   name:
     - "b200-fp8-stp-max-tpt-dep8-1p-1d"
     - "b200-fp8-stp-max-tpt-dep8-2p-1d"
+    - "b200-fp8-stp-max-tpt-dep8-3p-1d"
+    - "b200-fp8-stp-max-tpt-dep8-4p-1d"
   resources:
-    prefill_nodes: [1, 2]
-    prefill_workers: [1, 2]
-    decode_nodes: [1, 1]
-    decode_workers: [1, 1]
+    prefill_nodes: [1, 2, 3, 4]
+    prefill_workers: [1, 2, 3, 4]
+    decode_nodes: [1, 1, 1, 1]
+    decode_workers: [1, 1, 1, 1]
   backend:
     sglang_config:
-      prefill:
-        data-parallel-size: 8
-        enable-dp-attention: true
-        enable-dp-lm-head: true
-        moe-dense-tp-size: 1
-        max-running-requests: 1024
       decode:
         data-parallel-size: 8
         enable-dp-attention: true
         enable-dp-lm-head: true
-        moe-dense-tp-size: 1
-        max-running-requests: 1024
-        cuda-graph-max-bs: 1024
+        max-running-requests: [256, 512, 1024, 2048]
+        cuda-graph-max-bs: [256, 512, 1024, 2048]
   benchmark:
-    concurrencies: ["128", "256"]
+    concurrencies: ["288", "512", "1024", "2048"]
 
 
 # MTP max-throughput: dep8 decode, scale sweep 1p1d/1p2d/2p1d, adds EAGLE speculative decoding


### PR DESCRIPTION
All config can reuse this prefill config. But decode config for low-latency can do further fine tune. Should give large perf gain.

Summary: tune recipes/b200-fp8/8k1k.yaml prefill settings, adjust max throughput decode settings and benchmark concurrencies, and add launch queue plus per-token group quantization environment knobs. Testing: not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base configuration version to 0.9.1 with optimized resource allocation
  * Enhanced parallelism and load-balancing settings across deployment modes
  * Removed deprecated feature flags for improved configuration consistency
  * Added new performance optimization flags
  * Extended concurrency support to handle up to 2048 concurrent requests
  * Improved memory management and token limit configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->