### PR TITLE
Update b200 fp8 8k1k stp low latency

### DIFF
--- a/recipes/b200-fp8/8k1k.yaml
+++ b/recipes/b200-fp8/8k1k.yaml
@@ -136,7 +136,6 @@ base:
 
         # MoE
         moe-runner-backend: "flashinfer_trtllm"
-        # moe-dense-tp-size: 1
 
         # Other flags
         stream-interval: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized low-latency variant naming to "tp8" and simplified available variants.
  * Moved and adjusted load-balancing and decode concurrency settings to improve runtime balance.
  * Reduced decode worker/node counts for selected low-latency variants.
  * Introduced tuned backend decode limits for low-latency paths and updated throughput/benchmark concurrency profiles.
  * Adjusted MoE-related toggles and per-path parallel-size settings for variant-specific optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->