### PR TITLE
feat: support dynamo 1.0.0 (--kv-transfer-config, ToT install for vllm

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -339,10 +339,17 @@ class VLLMProtocol:
         mode_connector = config.pop("connector", None)
         connector = mode_connector if mode_connector is not None else self.connector
 
-        if isinstance(connector, list):
-            cmd.extend(["--connector"] + connector)
-        elif connector and connector not in ("null", "none", None):
-            cmd.extend(["--connector", connector])
+        if connector and connector not in ("null", "none", None):
+            # dynamo 1.0.0+: --connector is removed, use --kv-transfer-config
+            connector_map = {
+                "nixl": '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                "lmcache": '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}',
+            }
+            if isinstance(connector, str) and connector.lower() in connector_map:
+                cmd.extend(["--kv-transfer-config", connector_map[connector.lower()]])
+            elif isinstance(connector, str):
+                cmd.extend(["--kv-transfer-config", connector])
+
 
         # Check if this is DP+EP mode (data-parallel-size set)
         is_dp_mode = self._is_dp_mode(mode)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -675,12 +675,12 @@ class DynamoConfig:
     """Dynamo installation configuration.
 
     Only one of version, hash, or top_of_tree should be specified.
-    Defaults to version="0.8.0" (pip install).
+    Defaults to version="1.0.0" (pip install).
 
     Options:
         install: Whether to install dynamo at all (default: True). Set to False
                  if your container already has dynamo pre-installed.
-        version: Install specific version from PyPI (e.g., "0.8.0")
+        version: Install specific version from PyPI (e.g., "1.0.0")
         hash: Clone repo and checkout specific commit hash
         top_of_tree: Clone repo at HEAD (latest)
 
@@ -688,7 +688,7 @@ class DynamoConfig:
     """
 
     install: bool = True
-    version: str | None = "0.8.0"
+    version: str | None = "1.0.0"
     hash: str | None = None
     top_of_tree: bool = False
 
@@ -721,18 +721,14 @@ class DynamoConfig:
 
         return (
             f"echo 'Installing dynamo from source ({git_ref})...' && "
-            "apt-get update -qq && apt-get install -y -qq libclang-dev > /dev/null 2>&1 && "
-            "cd /sgl-workspace/ && "
+            "( command -v git > /dev/null 2>&1 || "
+            "(apt-get update -qq && apt-get install -y -qq git > /dev/null 2>&1) ) && "
+            "cd /tmp && "
             "git clone https://github.com/ai-dynamo/dynamo.git && "
             "cd dynamo && "
             f"{checkout_cmd + ' && ' if checkout_cmd else ''}"
-            "cd lib/bindings/python/ && "
-            'export RUSTFLAGS="${RUSTFLAGS:-} -C target-cpu=native" && '
-            "maturin build -o /tmp && "
-            "pip install /tmp/ai_dynamo_runtime*.whl && "
-            "cd /sgl-workspace/dynamo/ && "
-            "pip install -e . && "
-            "cd /sgl-workspace/sglang/ && "
+            "pip install --break-system-packages --quiet ai-dynamo-runtime && "
+            "pip install --break-system-packages --quiet -e . && "
             f"echo 'Dynamo installed from source ({git_ref})'"
         )
 


### PR DESCRIPTION
## Summary

Updates srt-slurm to support dynamo 1.0.0, which introduces breaking changes to the connector CLI interface and requires install path fixes for vLLM containers.

## Changes

### 1. `--connector` → `--kv-transfer-config` (`src/srtctl/backends/vllm.py`)

Dynamo 1.0.0 [removed the `--connector` flag](https://github.com/ai-dynamo/dynamo/pull/6450) for the vLLM backend. Passing `--connector nixl` now raises:

ValueError: `--connector` is no longer supported for the vLLM backend.


The new equivalent is `--kv-transfer-config` with a JSON config. This PR automatically translates:

| YAML config | Old CLI (dynamo ≤0.9.1) | New CLI (dynamo 1.0.0+) |
|---|---|---|
| `connector: nixl` | `--connector nixl` | `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'` |
| `connector: lmcache` | `--connector lmcache` | `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` |
| `connector: none` | `--connector none` | *(no flag — default behavior)* |

Existing YAML configs using `connector: nixl` continue to work without changes.

### 2. Default dynamo version updated to 1.0.0 (`src/srtctl/core/schema.py`)

- Default version: `0.8.0` → `1.0.0`

### 3. ToT source install fixed for vLLM containers (`src/srtctl/core/schema.py`)

The previous source install path assumed SGLang containers (`/sgl-workspace/`, `maturin`, Rust toolchain). vLLM public containers don't have `git`, `maturin`, or Rust.

New approach:
- Auto-installs `git` if not present
- Clones to `/tmp` (universal path)
- Installs `ai-dynamo-runtime` from PyPI (pre-built wheel, no Rust needed)
- Installs `ai-dynamo` Python package from source
- Works on **both** vLLM and SGLang containers

## Related

- dynamo `--connector` removal: https://github.com/ai-dynamo/dynamo/pull/6450
- dynamo `--kv-transfer-config` addition: https://github.com/ai-dynamo/dynamo/pull/6560
- dynamo DP routing fix: https://github.com/ai-dynamo/dynamo/pull/6695

