### PR TITLE
feat: auto-install sa-bench deps into isolated venv before benchmark

### DIFF
--- a/configs/vllm-container-deps.sh
+++ b/configs/vllm-container-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pip install msgpack

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -118,7 +118,8 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --ignore-eos \
         --request-rate 250 \
         --percentile-metrics ttft,tpot,itl,e2el \
-        --max-concurrency "$concurrency"
+        --max-concurrency "$concurrency" \
+        --trust-remote-code
 
     num_prompts=$((concurrency * 10))
     
@@ -147,6 +148,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --request-rate "${REQ_RATE}" \
         --percentile-metrics ttft,tpot,itl,e2el \
         --max-concurrency "$concurrency" \
+        --trust-remote-code \
         --use-chat-template \
         --save-result --result-dir "$result_dir" --result-filename "$result_filename"
     set +x


### PR DESCRIPTION
bench.sh now checks whether its Python dependencies (aiohttp, numpy, pandas, etc.) are available and, if any are missing, creates a venv at /tmp/sa-bench-venv with --system-site-packages and pip-installs them. Containers that already have everything skip the step entirely.

This keeps dep installation scoped to the benchmark process only — workers are unaffected.

Also adds a file `configs/vllm-container-deps.sh` , this can be used by future recipes which require the relevant dependencies there. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency management for the benchmark tooling with automatic environment setup and selective reuse of system packages.
  * Added a small helper script to ensure a required Python package (msgpack) is installed in container setups.

* **New Features**
  * Benchmark runs now include a flag to allow execution of model/tokenizer code from remote sources during warmup and main runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->