### PR TITLE
feat(vllm): support dynamo 1.0.0 --kv-transfer-config and --disaggreg…

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -10,6 +10,7 @@ Uses dynamo.vllm integration module.
 from __future__ import annotations
 
 import builtins
+import json
 from collections.abc import Sequence
 from dataclasses import field
 from pathlib import Path
@@ -55,17 +56,20 @@ class VLLMProtocol:
     This frozen dataclass both holds configuration AND implements the
     BackendProtocol methods for process allocation and launching.
 
+    dynamo 1.0.0+: ``--connector`` was removed; the ``connector`` field is now
+    translated to ``--kv-transfer-config`` with the appropriate JSON payload.
+
     Example YAML:
         backend:
           type: vllm
-          connector: nixl  # default connector (can be overridden per mode)
+          connector: nixl  # translated to --kv-transfer-config JSON
           prefill_environment:
             PYTHONUNBUFFERED: "1"
           vllm_config:
             prefill:
               tensor-parallel-size: 2
               gpu-memory-utilization: 0.9
-              connector: kvbm  # override connector for prefill
+              connector: lmcache  # override connector for prefill
             decode:
               tensor-parallel-size: 2
               gpu-memory-utilization: 0.85
@@ -82,10 +86,10 @@ class VLLMProtocol:
     # vLLM server CLI config per mode
     vllm_config: VLLMServerConfig | None = None
 
-    # Default KV connector(s): "nixl", "kvbm", ["kvbm", "nixl"], etc.
-    # Can be overridden per mode by setting "connector" in vllm_config.prefill/decode/aggregated
-    # Passed as --connector flag to dynamo.vllm
-    connector: str | list[str] | None = "nixl"
+    # Default KV connector: "nixl", "lmcache", or a raw JSON string for --kv-transfer-config.
+    # Can be overridden per mode by setting "connector" in vllm_config.prefill/decode/aggregated.
+    # dynamo 1.0.0+: translated to --kv-transfer-config (--connector was removed).
+    connector: str | None = "nixl"
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
@@ -327,22 +331,19 @@ class VLLMProtocol:
             ]
         )
 
-        # Disaggregation flags (different from SGLang's --disaggregation-mode)
-        if mode == "prefill":
-            cmd.append("--is-prefill-worker")
-        elif mode == "decode":
-            cmd.append("--is-decode-worker")
-        # agg mode: no flag (default behavior)
+        # Disaggregation mode (dynamo 1.0.0+: --is-prefill-worker/--is-decode-worker are deprecated)
+        if mode in ("prefill", "decode"):
+            cmd.extend(["--disaggregation-mode", mode])
 
-        # KV connector - check for mode-specific override first, then fall back to default
-        # Pop from config so it doesn't get added again by _config_to_cli_args
+        # KV connector → --kv-transfer-config (dynamo 1.0.0+: --connector was removed)
+        # Check for mode-specific override first, then fall back to default.
+        # Pop from config so it doesn't get added again by _config_to_cli_args.
         mode_connector = config.pop("connector", None)
         connector = mode_connector if mode_connector is not None else self.connector
 
-        if isinstance(connector, list):
-            cmd.extend(["--connector"] + connector)
-        elif connector and connector not in ("null", "none", None):
-            cmd.extend(["--connector", connector])
+        if connector and connector not in ("null", "none", None):
+            kv_transfer_cfg = _connector_to_kv_transfer_config(connector)
+            cmd.extend(["--kv-transfer-config", kv_transfer_cfg])
 
         # Check if this is DP+EP mode (data-parallel-size set)
         is_dp_mode = self._is_dp_mode(mode)
@@ -390,6 +391,30 @@ class VLLMProtocol:
         cmd.extend(_config_to_cli_args(config))
 
         return cmd
+
+
+_CONNECTOR_MAP: dict[str, dict[str, str]] = {
+    "nixl": {"kv_connector": "NixlConnector", "kv_role": "kv_both"},
+    "lmcache": {"kv_connector": "LMCacheConnectorV1", "kv_role": "kv_both"},
+    "kvbm": {
+        "kv_connector": "DynamoConnector",
+        "kv_connector_module_path": "kvbm.vllm_integration.connector",
+        "kv_role": "kv_both",
+    },
+}
+
+
+def _connector_to_kv_transfer_config(connector: str) -> str:
+    """Translate a connector shorthand to a --kv-transfer-config JSON string.
+
+    Known shorthands (e.g. "nixl", "lmcache") are expanded to the full JSON
+    config expected by vLLM.  Anything else is passed through as-is (assumed
+    to already be a valid JSON string).
+    """
+    preset = _CONNECTOR_MAP.get(connector.lower())
+    if preset is not None:
+        return json.dumps(preset)
+    return connector
 
 
 def _config_to_cli_args(config: dict[str, Any]) -> list[str]:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1244,3 +1244,129 @@ class TestVLLMDataParallelMode:
         # But should still have multi-node flags
         assert "--master-addr" in cmd
         assert "--nnodes" in cmd
+
+    # =========================================================================
+    # Connector → --kv-transfer-config tests (dynamo 1.0.0+)
+    # =========================================================================
+
+    def _build_cmd_with_connector(self, connector, mode="agg", mode_connector=None):
+        """Helper: build a vLLM worker command with the given connector setting."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Process
+
+        mode_config: dict = {}
+        if mode_connector is not None:
+            mode_config["connector"] = mode_connector
+
+        vllm_cfg_kwargs = {("aggregated" if mode == "agg" else mode): mode_config or None}
+        backend = VLLMProtocol(
+            connector=connector,
+            vllm_config=VLLMServerConfig(**vllm_cfg_kwargs),
+        )
+
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset([0, 1, 2, 3]),
+            sys_port=8081,
+            http_port=30000,
+            endpoint_mode=mode,
+            endpoint_index=0,
+            node_rank=0,
+        )
+
+        mock_runtime = MagicMock()
+        mock_runtime.model_path = Path("/model")
+        mock_runtime.is_hf_model = False
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            return backend.build_worker_command(
+                process=process,
+                endpoint_processes=[process],
+                runtime=mock_runtime,
+            )
+
+    def test_connector_nixl_generates_kv_transfer_config(self):
+        """connector: nixl → --kv-transfer-config with NixlConnector JSON."""
+        import json
+
+        cmd = self._build_cmd_with_connector("nixl")
+        assert "--kv-transfer-config" in cmd
+        assert "--connector" not in cmd
+        idx = cmd.index("--kv-transfer-config")
+        cfg = json.loads(cmd[idx + 1])
+        assert cfg["kv_connector"] == "NixlConnector"
+        assert cfg["kv_role"] == "kv_both"
+
+    def test_connector_lmcache_generates_kv_transfer_config(self):
+        """connector: lmcache → --kv-transfer-config with LMCacheConnectorV1 JSON."""
+        import json
+
+        cmd = self._build_cmd_with_connector("lmcache")
+        idx = cmd.index("--kv-transfer-config")
+        cfg = json.loads(cmd[idx + 1])
+        assert cfg["kv_connector"] == "LMCacheConnectorV1"
+
+    def test_connector_custom_json_passthrough(self):
+        """connector set to a raw JSON string is passed through as-is."""
+        import json
+
+        custom = '{"kv_connector":"MyCustomConnector","kv_role":"kv_both"}'
+        cmd = self._build_cmd_with_connector(custom)
+        idx = cmd.index("--kv-transfer-config")
+        assert cmd[idx + 1] == custom
+
+    def test_connector_null_skips_flag(self):
+        """connector: null should not emit --kv-transfer-config."""
+        cmd = self._build_cmd_with_connector(None)
+        assert "--kv-transfer-config" not in cmd
+        assert "--connector" not in cmd
+
+    def test_connector_none_string_skips_flag(self):
+        """connector: 'none' should not emit --kv-transfer-config."""
+        cmd = self._build_cmd_with_connector("none")
+        assert "--kv-transfer-config" not in cmd
+
+    def test_connector_kvbm_generates_kv_transfer_config(self):
+        """connector: kvbm → --kv-transfer-config with DynamoConnector JSON."""
+        import json
+
+        cmd = self._build_cmd_with_connector("kvbm")
+        idx = cmd.index("--kv-transfer-config")
+        cfg = json.loads(cmd[idx + 1])
+        assert cfg["kv_connector"] == "DynamoConnector"
+        assert cfg["kv_connector_module_path"] == "kvbm.vllm_integration.connector"
+
+    def test_mode_connector_overrides_default(self):
+        """Per-mode connector override takes precedence over default."""
+        import json
+
+        cmd = self._build_cmd_with_connector("nixl", mode="agg", mode_connector="lmcache")
+        idx = cmd.index("--kv-transfer-config")
+        cfg = json.loads(cmd[idx + 1])
+        assert cfg["kv_connector"] == "LMCacheConnectorV1"
+
+    def test_disaggregation_mode_flag_for_prefill(self):
+        """Prefill mode emits --disaggregation-mode prefill (not --is-prefill-worker)."""
+        cmd = self._build_cmd_with_connector("nixl", mode="prefill")
+        assert "--disaggregation-mode" in cmd
+        idx = cmd.index("--disaggregation-mode")
+        assert cmd[idx + 1] == "prefill"
+        assert "--is-prefill-worker" not in cmd
+
+    def test_disaggregation_mode_flag_for_decode(self):
+        """Decode mode emits --disaggregation-mode decode (not --is-decode-worker)."""
+        cmd = self._build_cmd_with_connector("nixl", mode="decode")
+        assert "--disaggregation-mode" in cmd
+        idx = cmd.index("--disaggregation-mode")
+        assert cmd[idx + 1] == "decode"
+        assert "--is-decode-worker" not in cmd
+
+    def test_agg_mode_no_disaggregation_flag(self):
+        """Aggregated mode should not emit any disaggregation flag."""
+        cmd = self._build_cmd_with_connector("nixl", mode="agg")
+        assert "--disaggregation-mode" not in cmd
+        assert "--is-prefill-worker" not in cmd
+        assert "--is-decode-worker" not in cmd


### PR DESCRIPTION
## Summary

Adapt the vLLM backend to `dynamo 1.0.0` breaking CLI changes (see [release notes](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0)).

This PR addresses two breaking changes that affect `srt-slurm`'s vLLM worker command generation:

1. **`--connector` removed → `--kv-transfer-config`** ([#6450](https://github.com/ai-dynamo/dynamo/pull/6450)):
   dynamo 1.0.0 removes the `--connector` flag. Disaggregated workers now require `--kv-transfer-config` with a JSON payload.
   - Added `_CONNECTOR_MAP` to translate shorthands (`nixl`, `lmcache`, `kvbm`)
     into the required JSON (e.g. `{"kv_connector":"NixlConnector","kv_role":"kv_both"}`).
   - Raw JSON strings are passed through for custom configs.
   - Changed `connector` field type from `str | list[str] | None` to `str | None`.

2. **`--is-prefill-worker`/`--is-decode-worker` deprecated → `--disaggregation-mode`**
   ([#6483](https://github.com/ai-dynamo/dynamo/pull/6483)):
   Replaced the boolean flags with the new `--disaggregation-mode prefill|decode` enum.

### Scope

Only `src/srtctl/backends/vllm.py` and `tests/test_configs.py` are changed. `schema.py` (default dynamo version, source install) is **not** bumped here, that should be coordinated in a repo-wide dynamo 1.0 migration PR that also covers SGLang and core schema changes.

### Other dynamo 1.0.0 breaking changes NOT addressed here

The following may need separate PRs:
- `--enforce-disagg` → `--decode-fallback` [#6615](https://github.com/ai-dynamo/dynamo/pull/6515)
- `--migration-limit` moved to Frontend only [#5918](https://github.com/ai-dynamo/dynamo/pull/5918)
- KV Router flags renamed to `--router-*` prefix [#6361](https://github.com/ai-dynamo/dynamo/pull/6361)
- KV events now opt-in via `--kv-events-config` [#6404](https://github.com/ai-dynamo/dynamo/pull/6404)
- `--enable-local-indexer` removed [#5941](https://github.com/ai-dynamo/dynamo/pull/5941)
- Env var renames: `DYNAMO_*` → `DYN_*` [#6358](https://github.com/ai-dynamo/dynamo/pull/6358), [#5882](https://github.com/ai-dynamo/dynamo/pull/5882)
- Default dynamo version bump in `schema.py`

## Test plan

- [x] 18 unit tests passed (10 new + 8 existing) — `pytest tests/test_configs.py -k TestVLLMDataParallelMode`
- [x] `srtctl` output shows `--kv-transfer-config '{...}'` and `--disaggregation-mode prefill|decode`
- [x] end-to-end SLURM job with dynamo 1.0.0 on GB200 2-node disagg (4P+4D, DP+EP with nixl)
- [x] `curl /v1/completions` against the running job returned valid inference response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vLLM connector configuration to use centralized KV transfer config approach for consistency
  * Simplified connector field to accept only string or None values
  * Enhanced support for mode-specific connector overrides

* **Tests**
  * Added comprehensive test coverage for connector configurations, KV transfer setups, and disaggregation mode behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->