### PR TITLE
trtllm nsys

### DIFF
--- a/src/srtctl/benchmarks/scripts/profiling/profile.sh
+++ b/src/srtctl/benchmarks/scripts/profiling/profile.sh
@@ -11,6 +11,8 @@
 model_name="${PROFILE_MODEL_NAME:-deepseek-ai/DeepSeek-R1}"
 head_node="${HEAD_NODE:-127.0.0.1}"
 head_port="${HEAD_PORT:-8000}"
+export AIPERF_RECORD_EXPORT_BATCH_SIZE=1  # Flush profile_export.jsonl after every x requests
+
 
 # Parse arguments
 n_prefill=$1
@@ -130,27 +132,57 @@ done
 if [[ "${PROFILING_MODE}" == "prefill" ]]; then
     echo ""
     echo "Generating profiling traffic..."
-    python3 -m sglang.bench_serving \
-        --backend sglang \
-        --model "${model_name}" \
-        --host "${head_node}" --port "${head_port}" \
-        --dataset-name random \
-        --max-concurrency "${PROFILE_CONCURRENCY}" \
-        --num-prompts 128 \
-        --random-input-len "${PROFILE_ISL}" \
-        --random-output-len "${PROFILE_OSL}" \
-        --random-range-ratio 1 \
-        --warmup-request 0
 
-    # Run lm-eval for additional profiling coverage
-    echo ""
-    echo "Running lm-eval..."
-    pip install lm-eval tenacity > /dev/null 2>&1
-    python -m lm_eval \
-        --model local-completions \
-        --tasks gsm8k \
-        --model_args "base_url=http://${head_node}:${head_port}/v1/completions,model=${model_name},tokenized_requests=False,tokenizer_backend=None,num_concurrent=${PROFILE_CONCURRENCY},timeout=6000,max_retries=1" \
-        --limit 10
+    mkdir -p /logs/artifacts/nsys_profile
+
+    if [[ "${PROFILING_BACKEND:-sglang}" == "trtllm" ]]; then
+        # TRTLLM: use aiperf (OpenAI-compatible), capture range is managed by
+        # TLLM_PROFILE_START_STOP on the worker side — no /start_profile call needed
+        aiperf profile \
+            --model "${model_name}" \
+            --tokenizer /model/ \
+            --tokenizer-trust-remote-code \
+            --endpoint-type chat \
+            --endpoint /v1/chat/completions \
+            --streaming \
+            --url "http://${head_node}:${head_port}" \
+            --synthetic-input-tokens-mean "${PROFILE_ISL}" \
+            --output-tokens-mean "${PROFILE_OSL}" \
+            --extra-inputs "max_tokens:${PROFILE_OSL}" \
+            --extra-inputs "min_tokens:${PROFILE_OSL}" \
+            --extra-inputs "ignore_eos:true" \
+            --concurrency "${PROFILE_CONCURRENCY}" \
+            --profile-export-level raw \
+            --artifact-dir /logs/artifacts/nsys_profile \
+            --request-count 50 \
+            --random-seed 42 \
+            -H 'Authorization: Bearer NOT USED'
+
+    else
+        # SGLang: use sglang.bench_serving
+        python3 -m sglang.bench_serving \
+            --backend sglang \
+            --model "${model_name}" \
+            --host "${head_node}" --port "${head_port}" \
+            --dataset-name random \
+            --max-concurrency "${PROFILE_CONCURRENCY}" \
+            --num-prompts 128 \
+            --random-input-len "${PROFILE_ISL}" \
+            --random-output-len "${PROFILE_OSL}" \
+            --random-range-ratio 1 \
+            --warmup-request 0
+
+            
+        # lm-eval for additional coverage (uses OpenAI /v1/completions — works for both backends)
+        echo ""
+        echo "Running lm-eval..."
+        pip install lm-eval tenacity > /dev/null 2>&1
+        python -m lm_eval \
+            --model local-completions \
+            --tasks gsm8k \
+            --model_args "base_url=http://${head_node}:${head_port}/v1/completions,model=${model_name},tokenized_requests=False,tokenizer_backend=None,num_concurrent=${PROFILE_CONCURRENCY},timeout=6000,max_retries=1" \
+            --limit 10
+    fi
 fi
 
 exit_code=$?

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -254,6 +254,7 @@ class BenchmarkStageMixin:
 
             # The profile.sh script only generates traffic when PROFILING_MODE=prefill
             env["PROFILING_MODE"] = "prefill"
+            env["PROFILING_BACKEND"] = self.config.backend.type
 
         return env
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -573,6 +573,7 @@ class ProfilingConfig:
     isl: int | None = None  # Input sequence length for profiling workload
     osl: int | None = None  # Output sequence length for profiling workload
     concurrency: int | None = None  # Batch size / concurrency
+    continue_benchmark_after_profiling: bool = False  # If true, does not kill benchmark when nsys profiling finishes 
 
     # Phase-specific profiling step configs
     prefill: ProfilingPhaseConfig | None = None
@@ -641,6 +642,11 @@ class ProfilingConfig:
         if self.is_torch:
             env["SGLANG_TORCH_PROFILER_DIR"] = f"{profile_dir}/{mode}"
 
+        # TRTLLM nsys: set TLLM_PROFILE_START_STOP so PyExecutor triggers cudaProfilerStart/Stop
+        if self.is_nsys and phase_config and phase_config.start_step is not None and phase_config.stop_step is not None:
+            env["TLLM_PROFILE_START_STOP"] = f"{phase_config.start_step}-{phase_config.stop_step}"
+            env["TLLM_LLMAPI_ENABLE_NVTX"] = "1"
+
         return env
 
     def get_nsys_prefix(self, output_file: str) -> list[str]:
@@ -655,21 +661,26 @@ class ProfilingConfig:
         if not self.is_nsys:
             return []
 
-        return [
+        cmd = [
             "nsys",
             "profile",
             "-t",
-            "cuda,nvtx",
+            "cuda,nvtx,ucx",
             "--cuda-graph-trace=node",
             "-c",
             "cudaProfilerApi",
             "--capture-range-end",
             "stop",
-            "--force-overwrite",
-            "true",
-            "-o",
-            output_file,
         ]
+
+        if self.continue_benchmark_after_profiling:
+            # Keep benchmark alive post-profiling until process exits 
+            # (used for TRTLLM where profiling stopped by TLLM_PROFILE_START_STOP env var)
+            cmd += ["--sample=none", "--kill", "none", "--wait", "all"]
+
+        cmd += ["--force-overwrite", "true", "-o", output_file]
+
+        return cmd
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
@@ -858,6 +869,9 @@ class SrtConfig:
         prof = self.profiling
         if not prof.enabled:
             return
+
+        if prof.is_torch and self.backend.type == "trtllm":
+            raise ValidationError("torch profiling is not supported for the trtllm backend; use nsys instead")
 
         # Traffic generator params are required when profiling is enabled
         if prof.isl is None or prof.osl is None or prof.concurrency is None:


### PR DESCRIPTION
Changes to enable range-based nsys profiling for TRTLLM deployments

  1. `src/srtctl/core/schema.py`:
    • get_nsys_prefix now always uses cuda,nvtx,ucx (ucx added)
    • New `continue_benchmark_after_profilng` parameter (default: False for backward compat) to not kill benchmark when nsys range finishes. When True, adds `--sample=none, --kill none, --wait all`
    • Added `TLLM_PROFILE_START_STOP` and `TLLM_LLMAPI_ENABLE_NVTX` env vars for TRTLLM
    • Added validation: torch profiling not supported for trtllm
  2. `src/srtctl/benchmarks/scripts/profiling/profile.sh`:
    • TRTLLM: uses aiperf for profiling traffic generation
    • SGLang: uses sglang.bench_serving (unchanged)
  3. `src/srtctl/cli/mixins/benchmark_stage.py`:
    • Added `PROFILING_BACKEND` env var


Example YAML usage for trtllm:
```
  profiling:
    type: nsys
    continue_benchmark_after_profiling: true
    isl: 4000  # ISL/OSL profile for 50 synthetic requests to bench on
    osl: 600
    concurrency: 1
    prefill:  # generates nsys-rep for each worker
      start_step: 10  # corresp. to TLLM_PROFILE_START_STOP
      stop_step: 50
    decode:
      start_step: 1000
      stop_step: 1100
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TRTLLM backend support for profiling with Nsight Systems
  * New `continue_benchmark_after_profiling` configuration option to control benchmark lifecycle after profiling
  * Enhanced profiling output to include UCX tracing data

* **Improvements**
  * Configuration validation now prevents incompatible profiling type and backend combinations with clearer error guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->