### PR TITLE
feat(postprocess): copy config YAML and sbatch script to log directory for rollup

### DIFF
--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import shlex
+import shutil
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -116,19 +117,42 @@ class PostProcessStageMixin:
             return config_value
         return os.environ.get(env_var)
 
+    def _copy_config_to_logs(self) -> None:
+        """Copy the job config YAML into the log directory so it's included in S3 uploads.
+
+        The config is saved to outputs/{job_id}/config.yaml at submit time,
+        but S3 syncs outputs/{job_id}/logs/. This copies it into logs/ so it
+        gets uploaded alongside benchmark results and worker logs.
+        """
+        output_dir = self.runtime.log_dir.parent
+        for name in ("config.yaml", "sbatch_script.sh"):
+            src = output_dir / name
+            if not src.exists():
+                continue
+            dst = self.runtime.log_dir / name
+            try:
+                shutil.copy2(src, dst)
+                logger.info("Copied %s to log directory", name)
+            except Exception as e:
+                logger.warning("Failed to copy %s to log directory: %s", name, e)
+
     def run_postprocess(self, exit_code: int) -> None:
         """Run post-processing after benchmark completion.
 
         Handles:
-        1. Rollup generation (benchmark-specific normalization)
-        2. Benchmark result extraction (reads rollup or falls back to raw)
-        3. srtlog parsing + S3 upload (if S3 configured)
-        4. Metrics reporting to dashboard (if status endpoint configured)
-        5. AI-powered failure analysis (only on failures, if enabled)
+        1. Copy config YAML into log directory (for S3 upload)
+        2. Rollup generation (benchmark-specific normalization)
+        3. Benchmark result extraction (reads rollup or falls back to raw)
+        4. srtlog parsing + S3 upload (if S3 configured)
+        5. Metrics reporting to dashboard (if status endpoint configured)
+        6. AI-powered failure analysis (only on failures, if enabled)
 
         Args:
             exit_code: Exit code from the benchmark run
         """
+        # Copy config into log directory so it's included in S3 upload
+        self._copy_config_to_logs()
+
         # Generate rollup first (benchmark-specific normalization)
         self._generate_rollup()
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -149,6 +149,7 @@ class TestPostProcessStageMixin:
         from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
 
         mixin = PostProcessStageMixin()
+        mixin._copy_config_to_logs = MagicMock()
         mixin._generate_rollup = MagicMock()
         mixin._extract_benchmark_results = MagicMock(return_value=None)
         mixin._run_postprocess_container = MagicMock(return_value=(None, None))
@@ -639,3 +640,63 @@ class TestS3UploadFaultTolerance:
 
         # Verify _report_metrics was still called (with None for s3_url, exit_code=0)
         mixin._report_metrics.assert_called_once_with(None, None, 0)
+
+
+class TestCopyConfigToLogs:
+    """Tests for copying config YAML to log directory."""
+
+    def _create_mixin_with_runtime(self, tmp_path):
+        """Create a mixin instance with runtime pointing to tmp_path/logs."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock()
+        mixin.runtime.log_dir = log_dir
+        return mixin, log_dir
+
+    def test_copies_config_yaml(self, tmp_path):
+        """Test config.yaml is copied from output dir to log dir."""
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        config_src = tmp_path / "config.yaml"
+        config_src.write_text("name: test-config\n")
+
+        mixin._copy_config_to_logs()
+
+        assert (log_dir / "config.yaml").exists()
+        assert (log_dir / "config.yaml").read_text() == "name: test-config\n"
+
+    def test_copies_sbatch_script(self, tmp_path):
+        """Test sbatch_script.sh is also copied."""
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        script_src = tmp_path / "sbatch_script.sh"
+        script_src.write_text("#!/bin/bash\necho hello\n")
+
+        mixin._copy_config_to_logs()
+
+        assert (log_dir / "sbatch_script.sh").exists()
+
+    def test_no_config_does_not_raise(self, tmp_path):
+        """Test graceful handling when config.yaml doesn't exist."""
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        mixin._copy_config_to_logs()
+
+        assert not (log_dir / "config.yaml").exists()
+
+    def test_copy_failure_does_not_raise(self, tmp_path):
+        """Test graceful handling when copy fails."""
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        config_src = tmp_path / "config.yaml"
+        config_src.write_text("name: test\n")
+
+        log_dir.chmod(0o444)
+        try:
+            mixin._copy_config_to_logs()  # Should not raise
+        finally:
+            log_dir.chmod(0o755)


### PR DESCRIPTION
copy config YAML and sbatch script to log directory for rollup

The config is saved to outputs/{job_id}/ at submit time but S3 syncs outputs/{job_id}/logs/. This copies config.yaml and sbatch_script.sh into the logs directory during post-processing so they're included in S3 uploads for full run reproducibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration files are now automatically copied to the logs directory during post-processing, making logs more self-contained and easier to troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->