### PR TITLE
Add kimi-k2.5 nvfp4 GB200 vllm-disagg configs for 8k1k

### DIFF
--- a/recipes/vllm/kimi-k2.5/disagg-gb200-1p4d-tep4.yaml
+++ b/recipes/vllm/kimi-k2.5/disagg-gb200-1p4d-tep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   version: 1.0.1
   install: true
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "gb200"

--- a/recipes/vllm/kimi-k2.5/disagg-gb200-3p1d.yaml
+++ b/recipes/vllm/kimi-k2.5/disagg-gb200-3p1d.yaml
@@ -9,7 +9,7 @@ dynamo:
   version: 1.0.1
   install: true
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "gb200"

--- a/recipes/vllm/kimi-k2.5/disagg-gb200-5p1d.yaml
+++ b/recipes/vllm/kimi-k2.5/disagg-gb200-5p1d.yaml
@@ -9,7 +9,7 @@ dynamo:
   version: 1.0.1
   install: true
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "gb200"

--- a/recipes/vllm/kimi-k2.5/disagg-gb200-6p1d-dep16.yaml
+++ b/recipes/vllm/kimi-k2.5/disagg-gb200-6p1d-dep16.yaml
@@ -9,7 +9,7 @@ dynamo:
   version: 1.0.1
   install: true
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "gb200"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple vLLM disaggregated serving recipes for GB200 GPU deployments with varied prefill/decode node topologies.
  * Recipes enable FP4 model precision, Dynamo frontend routing, and vLLM backend optimizations (FlashInfer MoE, expert parallel).
  * Per-phase KV caching (fp8), async decode scheduling, CUDA graph capture tuning, and sa-bench benchmark presets for high-concurrency testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->