### PR TITLE
feat: make sa-bench warmup and num_prompts multipliers configurable

### DIFF
--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -97,5 +97,7 @@ class SABenchRunner(BenchmarkRunner):
             str(prefill_gpus),
             str(decode_gpus),
             str(b.random_range_ratio) if b.random_range_ratio is not None else "0.8",
+            str(b.num_prompts_mult) if b.num_prompts_mult is not None else "10",
+            str(b.num_warmup_mult) if b.num_warmup_mult is not None else "2",
         ]
         return cmd

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -60,6 +60,8 @@ TOTAL_GPUS=${9:-0}
 PREFILL_GPUS=${10:-0}
 DECODE_GPUS=${11:-0}
 RANDOM_RANGE_RATIO=${12:-0.8}
+NUM_PROMPTS_MULT=${13:-10}
+NUM_WARMUP_MULT=${14:-2}
 
 # Parse endpoint into host:port
 HOST=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f1)
@@ -104,7 +106,7 @@ start_all_profiling
 
 for concurrency in "${CONCURRENCY_LIST[@]}"; do
 
-    num_warmup_prompts=$((concurrency * 2))
+    num_warmup_prompts=$((concurrency * NUM_WARMUP_MULT))
     python3 -u "${WORK_DIR}/benchmark_serving.py" \
         --model "${MODEL_NAME}" --tokenizer "${MODEL_PATH}" \
         --host "$HOST" --port "$PORT" \
@@ -121,7 +123,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --max-concurrency "$concurrency" \
         --trust-remote-code
 
-    num_prompts=$((concurrency * 10))
+    num_prompts=$((concurrency * NUM_PROMPTS_MULT))
     
     # Generate result filename based on mode
     if [ "$IS_DISAGGREGATED" = "true" ]; then

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -539,6 +539,8 @@ class BenchmarkConfig:
     ttft_threshold_ms: int | None = None  # Goodput TTFT threshold in ms (default: 2000)
     itl_threshold_ms: int | None = None  # Goodput ITL threshold in ms (default: 25)
     random_range_ratio: float | None = None  # Random input/output length range ratio (default: 0.8)
+    num_prompts_mult: int | None = None  # Multiplier for num_prompts = concurrency * mult (default: 10)
+    num_warmup_mult: int | None = None  # Multiplier for warmup prompts = concurrency * mult (default: 2)
 
     def get_concurrency_list(self) -> list[int]:
         if self.concurrencies is None:


### PR DESCRIPTION

## Description

### Problem
`bench.sh` hardcodes two key multipliers that control how many prompts are sent during warmup and benchmark phases:

```bash
num_warmup_prompts=$((concurrency * 2))   # line 107
num_prompts=$((concurrency * 10))          # line 124
```

These values are not always appropriate:
- **Warmup (`*2`)**: For profiling (nsys) runs, we want minimal warmup (`*1`) to reduce time before the actual capture window. For high-concurrency configs (cc=1024), `*2` means 2048 warmup prompts which is excessive.
- **Benchmark (`*10`)**: For quick validation sweeps, `*10` at high concurrency (e.g., cc=1024 → 10240 prompts) takes too long. Some configs already need `*1` or `*5`.

Neither multiplier was exposed to the YAML config layer, so changing them required editing `bench.sh` directly.

### Fix

Add two new optional fields to `BenchmarkConfig`:

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `num_prompts_mult` | `int` | `10` | Benchmark prompts = `concurrency * num_prompts_mult` |
| `num_warmup_mult` | `int` | `2` | Warmup prompts = `concurrency * num_warmup_mult` |

The values flow through three layers:

1. **`schema.py`** — new fields on `BenchmarkConfig`
2. **`sa_bench.py`** — passes them as positional args 13 and 14 to `bench.sh`
3. **`bench.sh`** — reads `${13:-10}` and `${14:-2}`, replaces hardcoded `* 10` and `* 2`

Defaults match the previous hardcoded values, so existing configs without these fields behave identically.

### Usage

```yaml
benchmark:
  type: sa-bench
  isl: 1024
  osl: 1024
  concurrencies: "128"
  num_prompts_mult: 1    # benchmark: 128 prompts (was 1280)
  num_warmup_mult: 1     # warmup: 128 prompts (was 256)
```

### Files Changed
- `src/srtctl/core/schema.py` — add `num_prompts_mult` and `num_warmup_mult` fields to `BenchmarkConfig` (+2)
- `src/srtctl/benchmarks/sa_bench.py` — pass new fields as positional args 13/14 to bench.sh (+2)
- `src/srtctl/benchmarks/scripts/sa-bench/bench.sh` — accept `NUM_PROMPTS_MULT` and `NUM_WARMUP_MULT` params, use them in place of hardcoded `10` and `2` (+4, -2)

### Tested
- Without config fields: defaults to `*10` / `*2` (backward compatible)
- With `num_prompts_mult: 1` and `num_warmup_mult: 1`: confirmed reduced prompt counts in sa-bench output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable benchmark parameters `num_prompts_mult` and `num_warmup_mult` to customize how prompt counts scale with concurrency. These parameters replace previously hardcoded values, with defaults of 10 and 2 respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->