### PR TITLE
Fix IP resolution corrupted by srun stderr in get_node_ip.sh

### DIFF
--- a/src/srtctl/core/ip_utils/get_node_ip.sh
+++ b/src/srtctl/core/ip_utils/get_node_ip.sh
@@ -178,8 +178,8 @@ get_node_ip() {
 
     # Execute the script on target node with single srun command
     local result
-    result=$(srun --jobid $slurm_job_id --nodes=1 --ntasks=1 --nodelist=$node bash -c "$ip_script" 2>&1)
-    local rc=$?
+    result=$(srun --jobid $slurm_job_id --nodes=1 --ntasks=1 --nodelist=$node bash -c "$ip_script" 2>&1 | grep -oP '^\d+\.\d+\.\d+\.\d+$' | tail -1)
+    local rc=${PIPESTATUS[0]}
 
     if [ $rc -eq 0 ] && [ -n "$result" ]; then
         echo "$result"


### PR DESCRIPTION
## Problem

  get_node_ip() in get_node_ip.sh uses 2>&1 to merge srun's stderr into stdout when resolving node IP
  addresses. Intermittently, srun outputs srun: Step created for StepId=... to stderr, which gets captured into
   the IP result variable:

Expected: "10.109.27.0"

Actual (when srun emits stderr): "srun: **_Step created for StepId=2195594.1_** 10.109.27.0"

  This corrupted string propagates into NATS_SERVER, ETCD_ENDPOINTS, and --dist-init-addr parameters:

  NATS_SERVER=nats://srun: Step created for StepId=2195594.1\n10.109.27.0:5162

  Workers then fail with: Exception: Failed to connect to NATS: NATS server URL is invalid: invalid port number.

  Impact: 12 out of 719 jobs (1.7%) were affected, all 12 failed. The bug is deterministic under some specific cases - srun: Step created is only emitted under certain scheduler timing/load conditions.

## Why srun prints this message

  In the slurm source (https://github.com/SchedMD/slurm/blob/master/src/srun/launch.c, function
  launch_create_job_step()), step creation runs in a retry loop. The key code is:

```
  if (job->step_ctx != NULL) {
      if (i > 0) {
          info("Step created for %ps", &step_req->step_id);
      }
      break;
  }
```

  - On first-attempt success (i == 0): the step is created silently — no message.
  - On retry success (i > 0): srun prints "Step created for StepId=..." to stderr at LOG_LEVEL_INFO
  (unconditional, no --verbose required).

  Retries are triggered when the initial step allocation encounters a transient condition:
  - ESLURM_PROLOG_RUNNING — node prolog still executing
  - ESLURM_NODES_BUSY — resources temporarily occupied by another step
  - Step creation timeout under controller load

## Fix

  Filter srun output through grep -oP '^\d+\.\d+\.\d+\.\d+$' to extract only valid IPv4 addresses, discarding
  any non-IP lines. Use ${PIPESTATUS[0]} to preserve srun's exit code through the pipe.

```
  - result=$(srun ... bash -c "$ip_script" 2>&1)
  - local rc=$?
  + result=$(srun ... bash -c "$ip_script" 2>&1 | grep -oP '^\d+\.\d+\.\d+\.\d+$' | tail -1)
  + local rc=${PIPESTATUS[0]}
```

## Log

  A lot of affected jobs with log evidence:
```
2026-04-07 19:43:14 [INFO] Port offset for this job: 430 (job_id: 2208343)
2026-04-07 19:43:14 [INFO] Waiting for NATS (port 4652) on nvlxxx7-T04...
2026-04-07 19:48:14 [ERROR] Error during sweep: NATS failed to start
Traceback (most recent call last):
  File "/xxxx/srt-slurm/src/srtctl/cli/do_sweep.py", line 268, in run
    head_proc = self.start_head_infrastructure(registry)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lxxxx/srt-slurm/src/srtctl/cli/do_sweep.py", line 194, in start_head_infrastructure
    raise RuntimeError("NATS failed to start")
RuntimeError: NATS failed to start
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced network node IP address detection and selection to improve system initialization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->